### PR TITLE
Added Steam Overlay load prevention + DayZ settings files

### DIFF
--- a/defs/settings.def
+++ b/defs/settings.def
@@ -20,6 +20,8 @@ SETTING(string, ScalingType, "scalingType", "linear")
 SETTING(bool, ForceAlwaysDownsamplingRes, "forceAlwaysDownsamplingRes", false)
 SETTING(bool, EmulateFlipBehaviour, "emulateFlipBehaviour", false)
 SETTING(bool, InterceptOnlySystemDlls, "interceptOnlySystemDlls", false)
+SETTING(bool, PreventSteamOverlay, "preventSteamOverlay", false)
+
 
 // Texture options
 SETTING(bool, EnableTextureDumping, "enableTextureDumping", false)

--- a/pack/config/DayZ/GeDoSaTo.ini
+++ b/pack/config/DayZ/GeDoSaTo.ini
@@ -1,0 +1,13 @@
+# Lines starting with "#" are ignored by GeDoSaTo and used to provide documentation
+# read them before changing anything!
+
+# DayZ SA configuration
+# NOTE: only works with Alternate Injection Method
+
+# Force disables Steam in-game overlay from getting loaded into the process
+# which caused some games to crash, even if it was disabled in Steam settings
+preventSteamOverlay true
+
+# Forces borderless windowed fullscreen mode instead of fullscreen mode
+# options: "true" (= force borderless windowed FS) and "false" (= unchanged)
+forceBorderlessFullscreen true

--- a/pack/config/GeDoSaTo.ini
+++ b/pack/config/GeDoSaTo.ini
@@ -65,6 +65,10 @@ emulateFlipBehaviour false
 # might increase compatibility with 3rd-party injectors, but decrease stability 
 interceptOnlySystemDlls false
 
+# Force disables Steam in-game overlay from getting loaded into the process
+# which caused some games to crash, even if it was disabled in Steam settings
+preventSteamOverlay false
+
 # For games which use strange methods to query resolutions,
 # injecting a new one might not work. In such cases, you can try replacing an
 # existing resolution. E.g. "overrideWidth 800", "overrideHeight 600" to replace 800x600

--- a/pack/config/whitelist.txt
+++ b/pack/config/whitelist.txt
@@ -26,3 +26,4 @@ lcgol                    || Lara Croft and the Guardian of Light
 tru                      || Tomb Raider: Underworld
 ffxiv                    || Final Fantasy XIV
 ffxiv*                   || Final Fantasy XIV Launcher or Configurator
+DayZ                     || DayZ Standalone

--- a/source/detouring.cpp
+++ b/source/detouring.cpp
@@ -56,6 +56,16 @@ namespace {
 
 GENERATE_INTERCEPT_HEADER(LoadLibraryA, HMODULE, WINAPI, _In_ LPCSTR lpLibFileName) {
 	SDLOG(2, "DetouredLoadLibraryA %s\n", lpLibFileName);
+
+	std::string fn(lpLibFileName);
+	boost::algorithm::to_lower(fn);
+	if (Settings::get().getPreventSteamOverlay() && boost::algorithm::ends_with(fn, "gameoverlayrenderer.dll"))
+	{
+		SDLOG(2, "-> Steam overlay detected, denying access to file\n");
+		SetLastError(ERROR_ACCESS_DENIED);
+		return NULL;
+	}
+
 	HMODULE mod = TrueLoadLibraryA(lpLibFileName);
 	// restart detour in case we missed anything
 	if(mod) restartDetour(lpLibFileName);
@@ -63,6 +73,16 @@ GENERATE_INTERCEPT_HEADER(LoadLibraryA, HMODULE, WINAPI, _In_ LPCSTR lpLibFileNa
 }
 GENERATE_INTERCEPT_HEADER(LoadLibraryW, HMODULE, WINAPI, _In_ LPCWSTR lpLibFileName) {
 	SDLOG(2, "DetouredLoadLibraryW %s\n", CW2A(lpLibFileName));
+
+	std::wstring fn(lpLibFileName);
+	boost::algorithm::to_lower(fn);
+	if (Settings::get().getPreventSteamOverlay() && boost::algorithm::ends_with(fn, L"gameoverlayrenderer.dll"))
+	{
+		SDLOG(2, "-> Steam overlay detected, denying access to file\n");
+		SetLastError(ERROR_ACCESS_DENIED);
+		return NULL;
+	}
+
 	HMODULE mod = TrueLoadLibraryW(lpLibFileName);
 	// restart detour in case we missed anything
 	if(mod) restartDetour(CW2A(lpLibFileName));
@@ -71,8 +91,19 @@ GENERATE_INTERCEPT_HEADER(LoadLibraryW, HMODULE, WINAPI, _In_ LPCWSTR lpLibFileN
 
 GENERATE_INTERCEPT_HEADER(LoadLibraryExA, HMODULE, WINAPI, _In_ LPCSTR lpLibFileName, _Reserved_ HANDLE hFile, _In_ DWORD dwFlags) {
 	SDLOG(2, "DetouredLoadLibraryExA %s\n", lpLibFileName);
+
 	string fn(lpLibFileName);
 	if(fn.find("GeDoSaTo") != fn.npos) return GetCurrentModule(); // find out why we need this 
+	if(fn.find("GeDoSaTo") != fn.npos) return GetCurrentModule(); // find out why we need this
+
+	boost::algorithm::to_lower(fn);
+	if (Settings::get().getPreventSteamOverlay() && boost::algorithm::ends_with(fn, "gameoverlayrenderer.dll"))
+	{
+		SDLOG(2, "-> Steam overlay detected, denying access to file\n");
+		SetLastError(ERROR_ACCESS_DENIED);
+		return NULL;
+	}
+
 	HMODULE mod = TrueLoadLibraryExA(lpLibFileName, hFile, dwFlags);
 	// restart detour in case we missed anything
 	if(mod) restartDetour(lpLibFileName);
@@ -80,8 +111,18 @@ GENERATE_INTERCEPT_HEADER(LoadLibraryExA, HMODULE, WINAPI, _In_ LPCSTR lpLibFile
 }
 GENERATE_INTERCEPT_HEADER(LoadLibraryExW, HMODULE, WINAPI, _In_ LPCWSTR lpLibFileName, _Reserved_ HANDLE hFile, _In_ DWORD dwFlags) {
 	SDLOG(2, "DetouredLoadLibraryExW %s\n", CW2A(lpLibFileName));
+
 	string fn((CW2A(lpLibFileName)));
 	if(fn.find("GeDoSaTo") != fn.npos) return GetCurrentModule(); // find out why we need this
+
+	boost::algorithm::to_lower(fn);
+	if (Settings::get().getPreventSteamOverlay() && boost::algorithm::ends_with(fn, "gameoverlayrenderer.dll"))
+	{
+		SDLOG(2, "-> Steam overlay detected, denying access to file\n");
+		SetLastError(ERROR_ACCESS_DENIED);
+		return NULL;
+	}
+
 	HMODULE mod = TrueLoadLibraryExW(lpLibFileName, hFile, dwFlags);
 	// restart detour in case we missed anything
 	if(mod) restartDetour(CW2A(lpLibFileName));


### PR DESCRIPTION
Initial support for DayZ Standalone with working Borderless mode and post-processing effects. Only works with Alternate Injection Method.

For some weird reasons Steam in-game overlay caused DayZ to crash when GeDoSaTo was enabled and overlay disabled in Steam settings, so this patch also includes an option for preventing GameOverlayRenderer.dll to load which effectively disables the overlay completely.
