### PR TITLE
Makes Farcry 1 compatible.

### DIFF
--- a/source/detouring.cpp
+++ b/source/detouring.cpp
@@ -62,6 +62,11 @@ namespace {
 			SetLastError(ERROR_ACCESS_DENIED);
 			return true;
 		}
+		if (boost::algorithm::ends_with(fn, L"dfhengine.dll")) {
+			SDLOG(2, "-> DFHEngine (FarCry ad system) detected, denying access to file\n");
+			SetLastError(ERROR_ACCESS_DENIED);
+			return true;
+		}
 		return false;
 	}
 }


### PR DESCRIPTION
Makes Farcry 1 compatible. The DFHEngine.dll was preventing the game to load so I added it to the preventDll mechanism. It's totally safe to prevent it from loading globally as it's only used by the FarCry 1 free version to originally display ads
