### PR TITLE
Added option to disable early Steam Overlay loading.

### DIFF
--- a/defs/settings.def
+++ b/defs/settings.def
@@ -21,6 +21,7 @@ SETTING(bool, ForceAlwaysDownsamplingRes, "forceAlwaysDownsamplingRes", false)
 SETTING(bool, EmulateFlipBehaviour, "emulateFlipBehaviour", false)
 SETTING(bool, InterceptOnlySystemDlls, "interceptOnlySystemDlls", false)
 SETTING(bool, PreventSteamOverlay, "preventSteamOverlay", false)
+SETTING(bool, LoadSteamOverlayEarly, "loadSteamOverlayEarly", true)
 SETTING(bool, LoadD3DEarly, "loadD3DEarly", false)
 
 // Texture options

--- a/pack/config/GeDoSaTo.ini
+++ b/pack/config/GeDoSaTo.ini
@@ -69,6 +69,9 @@ interceptOnlySystemDlls false
 # which caused some games to crash, even if it was disabled in Steam settings
 preventSteamOverlay false
 
+# Loads Steam overlay early
+loadSteamOverlayEarly true
+
 # Loads D3D dlls early - may cause some games to recognize GeDoSaTo which wouldn't otherwise
 loadD3DEarly false
 

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -84,7 +84,7 @@ BOOL WINAPI DllMain(HMODULE hDll, DWORD dwReason, PVOID pvReserved) {
 		KeyActions::get().load();
 		KeyActions::get().report();
 
-		if(!Settings::get().getPreventSteamOverlay()) {
+		if(!Settings::get().getPreventSteamOverlay() && Settings::get().getLoadSteamOverlayEarly()) {
 			SDLOG(2, "Attempting to pre-load Steam overlay dll.\n");
 			LoadLibrary("gameoverlayrenderer.dll");
 		}


### PR DESCRIPTION
Temporary workaround for issue #28.
