### PR TITLE
Remove LoS hash

### DIFF
--- a/pack/config/CastlevaniaLoSUE/GeDoSaTo.ini
+++ b/pack/config/CastlevaniaLoSUE/GeDoSaTo.ini
@@ -4,5 +4,3 @@
 # Castlevania: Lords of Shadow - Ultimate Edition configuration
 
 # HUDless
-injectPSHash 05a43efc
-injectDelayAfterDraw true


### PR DESCRIPTION
This hash is too early as it also removes the last light pass, so it's no good.
There's no replacement either, LoS is one of those games where the hash changes depending on the scene.
