### PR TITLE
Added config files for Earth 2160.

### DIFF
--- a/pack/config/Earth2160_NO_SSE/GeDoSaTo.ini
+++ b/pack/config/Earth2160_NO_SSE/GeDoSaTo.ini
@@ -1,0 +1,10 @@
+# This is a profile file for Earth2160_NO_SSE
+
+# Game will crash when switching resolutions unless this is true
+forceBorderlessFullscreen true
+
+# Ensure the actual cursor position match its visual position on-screen
+modifyGetCursorPos true
+modifySetCursorPos true
+interceptWindowProc true
+adjustMessagePt true

--- a/pack/config/Earth2160_SSE/GeDoSaTo.ini
+++ b/pack/config/Earth2160_SSE/GeDoSaTo.ini
@@ -1,0 +1,12 @@
+# Lines starting with "#" are ignored by GeDoSaTo and used to provide documentation
+
+# This is a profile file for Earth2160_SSE
+
+# Game will crash when switching resolutions unless this is true
+forceBorderlessFullscreen true
+
+# Ensure the actual cursor position match its visual position on-screen
+modifyGetCursorPos true
+modifySetCursorPos true
+interceptWindowProc true
+adjustMessagePt true

--- a/pack/config/whitelist.txt
+++ b/pack/config/whitelist.txt
@@ -45,6 +45,7 @@ dota                         || Dota 2
 DragonAge2                   || Dragon Age 2
 DragonAge2*                  || Dragon Age 2 Launcher or Configurator
 EoCApp                       || Divinity: Original Sin
+Earth2160*                   || Earth 2160
 Fallout3                     || Fallout 3
 FalloutLauncher              || Fallout 3 Launcher
 fear                         || F.E.A.R.


### PR DESCRIPTION
Added config files with comments for Earth 2160 as well as an
appropriately-updated whitelist. No HUD-less due to the main and HUD
images being rendered simultaneously according to GeDoSaTo image dumps (representative sample [here.](https://www.dropbox.com/s/nha1y03fgvkn466/Earth2160_ImageDump.zip?dl=0))
