### PR TITLE
Improvements to SAO

### DIFF
--- a/include/plugins/generic_depth.h
+++ b/include/plugins/generic_depth.h
@@ -10,6 +10,7 @@ class GenericDepthPlugin : public GenericPlugin {
 	bool doAO = true;
 	bool isOrigDssRestored = false;
 	bool isOrigDssReplaced = false;
+	bool isAspectRatioFixNeeded = false;
 
 	unsigned countClear;
 	unsigned drw, drh, dssw, dssh;

--- a/include/ssao.h
+++ b/include/ssao.h
@@ -16,14 +16,14 @@ public:
 	SSAO(IDirect3DDevice9 *device, int width, int height, unsigned strength, Type type, Blur blur, bool useSRGB, bool readHWDepth);
     virtual ~SSAO();
 
-	void go(IDirect3DTexture9 *frame, IDirect3DTexture9 *depth, IDirect3DSurface9 *dst);
-	void goHDR(IDirect3DTexture9 *frame, IDirect3DTexture9 *depth, IDirect3DSurface9 *dst);
+	void go(IDirect3DTexture9 *frame, IDirect3DTexture9 *depth, IDirect3DSurface9 *dst, bool scaleToCustomAR);
+	void goHDR(IDirect3DTexture9 *frame, IDirect3DTexture9 *depth, IDirect3DSurface9 *dst, bool scaleToCustomAR);
 
 	void dumpFrame();
 	void reloadShader();
 
 private:
-	int width, height;
+	int width, height, dwidth, dheight;
 	size_t blurPasses;
 	bool dumping = false;
 	unsigned strength;
@@ -33,12 +33,12 @@ private:
 
 	ID3DXEffect *effect = NULL;
 	
-	RenderTargetPtr buffer1, buffer2, hdrBuffer, halfZBuffer;
+	RenderTargetPtr buffer1, buffer2, hdrBuffer, CSZBuffer;
 
-	D3DXHANDLE depthTexHandle, frameTexHandle, prevPassTexHandle, noiseTexHandle, isBlurHorizontalHandle;
+	D3DXHANDLE depthTexHandle, frameTexHandle, prevPassTexHandle, noiseTexHandle, isBlurHorizontalHandle, projInfoHandle;
 	
-	void downsamplePass(IDirect3DTexture9 *depth, IDirect3DSurface9* dst);
-	void mainSsaoPass(IDirect3DTexture9 *depth, IDirect3DSurface9 *dst);
+	void reconstructCSZPass(IDirect3DTexture9 *depth, IDirect3DSurface9* dst);
+	void mainSsaoPass(IDirect3DTexture9 *depth, IDirect3DSurface9 *dst, bool scaleToCustomAR);
 	void blurPass(IDirect3DTexture9 *depth, IDirect3DTexture9* src, IDirect3DSurface9* dst, bool horizontal);
 	void combinePass(IDirect3DTexture9* frame, IDirect3DTexture9* ao, IDirect3DSurface9* dst);
 };

--- a/pack/assets/dx9/SAO.fx
+++ b/pack/assets/dx9/SAO.fx
@@ -26,59 +26,80 @@
 
   */
 
-//////////////////////////////////////////////////////// TWEAKABLE VALUES ////////////////////////////////////////////////////////////
+//////////////////////////////////////////////////////// TWEAKABLE VALUES /////////////////////////////////////////////////////////////
 
-//#define SHOW_SSAO
+//#define SHOW_SSAO           /** Uncomment this to display the bare SSAO output */
+//#define SHOW_DEPTH          /** Shows depth texture. Useful to debug if you get no AO (white output) when #define SHOW_SSAO is on */
 
-/** manual nearZ/farZ values to compensate the fact we do not have access to the real projection matrix from the game */
-static const float nearZ = 0.1;
-static const float farZ = 22.0;
-
-/** Used for preventing AO computation on the sky (at infinite depth) and defining the CS Z to bilateral depth key scaling.
-This need not match the real far plane*/
-/** If you can't see any AO output at all make sure this value isn't too low :] */
-#define FAR_PLANE_Z (16.2)
-
-/** Quality */
-#define NUM_SAMPLES (9)
+/** Manual nearZ/farZ values to compensate the fact we do not have access to the real projection matrix from the game */
+/** This is key for the effect to look right. Basically you need to define the boundaries of the space you're going to shade */
+/** Usually nearZ is (0..10) and farZ is (10..300). Experiment with these until you approximate the right values for the game */
+static float nearZ = 0.1;
+static float farZ = 40.0;
 
 /** intensity : darkending factor, e.g., 1.0 */
 /** aoClamp : brightness fine-tuning (the higher the darker) */
 #ifdef SSAO_STRENGTH_LOW
-float intensity = 1.0;
-float aoClamp = 0.16;
+	float intensity = 1.0;
+	float aoClamp = 0.13;
 #endif
 
 #ifdef SSAO_STRENGTH_MEDIUM
-float intensity = 1.0;
-float aoClamp = 0.26;
+	float intensity = 1.0;
+	float aoClamp = 0.25;
 #endif
 
 #ifdef SSAO_STRENGTH_HIGH
-float intensity = 1.0;
-float aoClamp = 0.36;
+	float intensity = 1.0;
+	float aoClamp = 0.5;
 #endif
 
-//comment this line to not take pixel brightness into account (the higher the more AO will blend into bright surfaces)
-#define LUMINANCE_CONSIDERATION
-extern float luminosity_threshold = 0.5;
+/** Quality. Range is (1..30). */
+#define NUM_SAMPLES (6)
+
+/** More detailed distribution of the AO (imo). You'll need to tweak the intensity parameter accordingly */
+//#define HIGH_QUALITY
 
 /** World-space AO radius in scene units (r).  e.g., 1.0m */
+/** Usually you'll want tweak projScale parameter in conjunction with this. They *are* related */
+/** Radius is also linked to intensity such as intensity / radius^6 (see intensityDivR6 below) 
+*except* for HIGH_QUALITY mode */
 static const float radius = 0.6;
-/** radius*radius*/
-static const float radius2 = (radius*radius);
 
 /** Bias to avoid AO in smooth corners, e.g., 0.01m */
-static const float bias = 0.20f;
+/** Use this to push the darkening farther away from the models so it is not stuck on the geometry itself */
+static const float bias = 0.08f;
 
 /** The height in pixels of a 1m object if viewed from 1m away.
 You can compute it from your projection matrix.  The actual value is just
 a scale factor on radius; you can simply hardcode this to a constant (~500)
 and make your radius value unitless (...but resolution dependent.)  */
-static const float projScale = -0.6f;
+/** This setting tends to extend the range of occlusion, much like a radius increase
+but without affecting the intensity */
+static const float projScale = 0.3f;
+
+/** Comment this line to not take pixel brightness into account (the higher the more AO will blend into bright surfaces) */
+#define LUMINANCE_CONSIDERATION
+extern float luminosity_threshold = 0.6;
+
+/** Used for preventing AO computation on the sky (at infinite depth) and defining the CS Z to bilateral depth key scaling. */
+/** This need not match the real far plane */
+/** This goes together with nearZ/farZ values. If you can't see any (or partial) AO output at all make sure this value isn't too low :] */
+#define FAR_PLANE_Z (100.0)
+
+/** Falloff function type */
+	// 1: From the HPG12 paper
+	// 2: Smoother transition to zero (lowers contrast, smoothing out corners). [Recommended]
+	// 3: Medium contrast (which looks better at high radii), no division.
+	// 4: Low contrast, no division operation
+#define FALLOFF_FUNCTION 2
+
+/** Epsilon (read the SAO paper for details). Basically larger values (ie. 0.02) avoid overdarkening within craks */
+const float epsilon = 0.001;
 
 /** Increase to make edges crisper. Decrease to reduce temporal flicker. */
-#define EDGE_SHARPNESS     (0.1)
+// [Boulotaur2024] I recommand leaving low values because temporal flicker really *is* the problem
+#define EDGE_SHARPNESS     (0.4)
 
 /** Step in 2-pixel intervals since we already blurred against neighbors in the
 first AO pass.  This constant can be increased while R decreases to improve
@@ -88,12 +109,12 @@ Morgan found that a scale of 3 left a 1-pixel checkerboard grid that was
 unobjectionable after shading was applied but eliminated most temporal incoherence
 from using small numbers of sample taps.
 */
-#define SCALE               (2)
+#define SCALE               (3)
 
 /** Filter radius in pixels. This will be multiplied by SCALE. */
-#define R                   (3)
+#define R                   (6)
 
-///////////////////////////////////////////////////END OF TWEAKABLE VALUES ///////////////////////////////////////////////////////////
+/////////////////////////////////////////////////// END OF TWEAKABLE VALUES ///////////////////////////////////////////////////////////
 
 static const int ROTATIONS[] = { 1, 1, 2, 3, 2, 5, 2, 3, 2,
 3, 3, 5, 5, 3, 4, 7, 5, 5, 7,
@@ -110,15 +131,19 @@ static const int ROTATIONS[] = { 1, 1, 2, 3, 2, 5, 2, 3, 2,
 // taps from lining up.  This particular choice was tuned for NUM_SAMPLES == 9
 static const int NUM_SPIRAL_TURNS = ROTATIONS[NUM_SAMPLES-1];
 
+/** radius*radius*/
+static const float radius2 = (radius*radius);
+static float intensityDivR6 = intensity / pow(radius, 6.0f);
+
 // [Boulotaur2024] Not used anymore -> mipmaps cause flashing (probably due to my poor implementation)
-// // If using depth mip levels, the log of the maximum pixel offset before we need to switch to a lower 
-// // miplevel to maintain reasonable spatial locality in the cache
-// // If this number is too small (< 3), too many taps will land in the same pixel, and we'll get bad variance that manifests as flashing.
-// // If it is too high (> 5), we'll get bad performance because we're not using the MIP levels effectively
+// If using depth mip levels, the log of the maximum pixel offset before we need to switch to a lower 
+// miplevel to maintain reasonable spatial locality in the cache
+// If this number is too small (< 3), too many taps will land in the same pixel, and we'll get bad variance that manifests as flashing.
+// If it is too high (> 5), we'll get bad performance because we're not using the MIP levels effectively
 // #define LOG_MAX_OFFSET 3
 
 // // This must be less than or equal to the MAX_MIP_LEVEL defined in SSAO.cpp
-// #define MAX_MIP_LEVEL (4)
+// #define MAX_MIP_LEVEL (5)
 
 #ifndef USE_SRGB
 #define USE_SRGB true
@@ -189,10 +214,10 @@ pixels and camera-space z < 0.  Assumes that the upper-left pixel center
 is at (0.5, 0.5) [but that need not be the location at which the sample tap
 was placed!]
 */
+float4 projInfo;
 float3 reconstructCSPosition(float2 S, float z)
 {
-	// return float3((S.xy * projInfo.xy + projInfo.zw) * z, z);
-	return float3(S, z);
+	return float3(( (S.xy * SCREEN_SIZE) * projInfo.xy + projInfo.zw) * z, z);
 }
 
 /** Reconstructs screen-space unit normal from screen-space position */
@@ -220,7 +245,7 @@ float CSZToKey(float z)
     return clamp(z * (1.0 / FAR_PLANE_Z), 0.0, 1.0);
 }
 
-/** "camera-space z < 0" */
+/** Negative, "linear" values in world-space units */
 float LinearizeDepth(float depth)
 {
 	return rcp(depth * ((farZ - nearZ) / (-farZ * nearZ)) + farZ / (farZ * nearZ));
@@ -231,10 +256,10 @@ float3 getPosition(float2 ssP)
 {
     float3 P;
 
-    P.z = tex2D(depthSampler, ssP).r;
+	P.z = tex2D(depthSampler, ssP).r;
 
     // Offset to pixel center
-	P = reconstructCSPosition(float2(ssP) + float2(0.5, 0.5), P.z);
+	P = reconstructCSPosition(ssP, P.z);
     return P;
 }
 
@@ -246,17 +271,17 @@ float3 getOffsetPosition(float2 ssC, float2 unitOffset, float ssR)
 	//int mipLevel = clamp((int)floor(log2(ssR)) - LOG_MAX_OFFSET, 0, MAX_MIP_LEVEL);
 	//int mipLevel = 4;
 
-    float2 ssP = float2(ssR*unitOffset) + ssC;
+    float2 ssP = ssR*unitOffset + ssC;
 
     float3 P;
 
 	// Divide coordinate by 2^mipLevel
 	//P.z = tex2Dlod(depthSampler, float4(ssP * pow(0.5, -mipLevel), 0, mipLevel)).r;
 	//P.z = tex2D(depthSampler, ssP * pow(0.5, -mipLevel)).r;
-    P.z = tex2D(depthSampler, ssP).r;	
+	P.z = tex2D(depthSampler, ssP).r;
 
     // Offset to pixel center
-	P = reconstructCSPosition(float2(ssP) + float2(0.5, 0.5), P.z);
+	P = reconstructCSPosition(ssP, P.z);
 
     return P;
 }
@@ -285,23 +310,32 @@ float sampleAO(in float2 ssC, in float3 C, in float3 n_C, in float ssDiskRadius,
     float vv = dot(v, v);
     float vn = dot(v, n_C);
 
-    const float epsilon = 0.001;   // Original implementation : epsilon = 0.01;
-
-    // A: From the HPG12 paper
-    // Note large epsilon to avoid overdarkening within cracks
-    //return float(vv < radius2) * max((vn - bias) / (epsilon + vv), 0.0) * radius2 * 0.6;
-
-    // B: Smoother transition to zero (lowers contrast, smoothing out corners). [Recommended]
-    //float f = max(radius2 - vv, 0.0); return f * f * f * max((vn - bias) / (epsilon + vv), 0.0);
-	float f = max(radius2 - vv, 0.0); return f * f * f * max((vn - bias) / (epsilon + vv), 0.0);
-
-    // C: Medium contrast (which looks better at high radii), no division.  Note that the 
-    // contribution still falls off with radius^2, but we've adjusted the rate in a way that is
-    // more computationally efficient and happens to be aesthetically pleasing.
-    //return 4.0 * max(1.0 - vv * 1.0 / radius2, 0.0) * max(vn - bias, 0.0);
-
-    // D: Low contrast, no division operation
-    //return 2.0 * float(vv < radius * radius) * max(vn - bias, 0.0);
+	#ifdef HIGH_QUALITY
+		// Addition from http://graphics.cs.williams.edu/papers/DeepGBuffer13/	
+		// Epsilon inside the sqrt for rsqrt operation
+		float f = max(1.0 - vv * (1.0 / radius2), 0.0); return f * max((vn - bias) * rsqrt(epsilon + vv), 0.0);
+	#else
+		// [Boulotaur2024] yes branching is bad but choice is good...
+		[branch] if( FALLOFF_FUNCTION == 1 )
+					// A: From the HPG12 paper
+					// Note large epsilon to avoid overdarkening within cracks
+					return float(vv < radius2) * max((vn - bias) / (epsilon + vv), 0.0) * radius2 * 0.6;
+				else if( FALLOFF_FUNCTION == 2 ) {
+					// B: Smoother transition to zero (lowers contrast, smoothing out corners). [Recommended]
+					float f = max(radius2 - vv, 0.0); return f * f * f * max((vn - bias) / (epsilon + vv), 0.0);
+				}
+				else if( FALLOFF_FUNCTION == 3 )
+					// C: Medium contrast (which looks better at high radii), no division.  Note that the 
+					// contribution still falls off with radius^2, but we've adjusted the rate in a way that is
+					// more computationally efficient and happens to be aesthetically pleasing.
+					return 4.0 * max(1.0 - vv * 1.0 / radius2, 0.0) * max(vn - bias, 0.0);
+				else if( FALLOFF_FUNCTION == 3 )
+					// D: Low contrast, no division operation
+					return 2.0 * float(vv < radius * radius) * max(vn - bias, 0.0);
+				else
+					// D: Low contrast, no division operation
+					return 4.0 * max(1.0 - vv * 1.0 / radius2, 0.0) * max(vn - bias, 0.0);			
+	#endif
 }
 
 /** Used for packing Z into the GB channels */
@@ -326,19 +360,19 @@ float4 reconstructCSZPass(VSOUT IN) : COLOR0
 }
 
 // extern int previousMIPNumber;
-
-float4 downsamplePass(VSOUT IN) : COLOR0
-{
-	// int2 ssP = pixel.texCoords * float2(renderTargetSize[SIZECONST_WIDTH], renderTargetSize[SIZECONST_HEIGHT]);
+// extern float3 LastMipInfo;
+// float4 downsamplePass(VSOUT IN) : COLOR0
+// {
+	// // int2 ssP = pixel.texCoords * float2(renderTargetSize[SIZECONST_WIDTH], renderTargetSize[SIZECONST_HEIGHT]);
 	// float2 ssP = IN.UVCoord;
 
-	// Rotated grid subsampling to avoid XY directional bias or Z precision bias while downsampling
-	// fragment.color = source.Load(int3(ssP * 2 + int2((ssP.y & 1) ^ 1, (ssP.x & 1) ^ 1), 0)); // DX11
-	// return tex2Dlod(depthSampler, float4(ssP * 2 + float2(((ssP.y - floor(ssP.y)) * 2) != 1, ((ssP.x - floor(ssP.x)) * 2) != 1), 0, previousMIPNumber));
+	// // Rotated grid subsampling to avoid XY directional bias or Z precision bias while downsampling
+	// // fragment.color = source.Load(int3(ssP * 2 + int2((ssP.y & 1) ^ 1, (ssP.x & 1) ^ 1), 0)); // DX11
+	// // return tex2Dlod(depthSampler, float4(ssP * 2 + float2(((ssP.y - floor(ssP.y)) * 2) != 1, ((ssP.x - floor(ssP.x)) * 2) != 1), 0, LastMipInfo.z));
 
-	// Plain dumb Linear mip-map instead of Rotated grid subsampling. (I can't make that one work unfortunately :/)
-	return tex2Dlod(depthSampler, float4(IN.UVCoord, 0, 0));
-}
+	// // Plain dumb Linear mip-map instead of Rotated grid subsampling. (I can't make that one work unfortunately :/)
+	// return tex2Dlod(depthSampler, float4(ssP, 0, LastMipInfo.z));
+// }
 
 // Input: It uses texture coords as the random number seed.
 // Output: Random number: [0,1), that is between 0.0 and 0.999999... inclusive.
@@ -350,8 +384,36 @@ float random( float2 p )
   // Most (all?) known transcendental numbers will (generally) work.
   const float2 r = float2(
     23.1406926327792690,  // e^pi (Gelfond's constant)
-     2.6651441426902251); // 2^sqrt(2) (Gelfond-Schneider constant)
+     2.6651441426902251); // 2^sqrt(2) (Gelfond–Schneider constant)
   return frac( cos( fmod( 123456789., 1e-7 + 256. * dot(p,r) ) ) );
+}
+
+// by Morgan McGuire https://www.shadertoy.com/view/4dS3Wd
+// All noise functions are designed for values on integer scale.
+// They are tuned to avoid visible periodicity for both positive and
+// negative coordinates within a few orders of magnitude.
+float hash(float n) { return frac(sin(n) * 1e4); }
+float hash(float2 p) { return frac(1e4 * sin(17.0 * p.x + p.y * 0.1) * (0.1 + abs(sin(p.y * 13.0 + p.x)))); }
+
+float noise1(float2 x) {
+    float2 i = floor(x);
+    float2 f = frac(x);
+
+	// Four corners in 2D of a tile
+	float a = hash(i);
+    float b = hash(i + float2(1.0, 0.0));
+    float c = hash(i + float2(0.0, 1.0));
+    float d = hash(i + float2(1.0, 1.0));
+
+    // Simple 2D lerp using smoothstep envelope between the values.
+	// return float3(lerp(lerp(a, b, smoothstep(0.0, 1.0, f.x)),
+	//			lerp(c, d, smoothstep(0.0, 1.0, f.x)),
+	//			smoothstep(0.0, 1.0, f.y)));
+
+	// Same code, with the clamps in smoothstep and common subexpressions
+	// optimized away.
+    float2 u = f * f * (3.0 - 2.0 * f);
+	return lerp(a, b, u.x) + (c - a) * u.y * (1.0 - u.x) + (d - b) * u.x * u.y;
 }
 
 #define visibility      output.r
@@ -379,10 +441,9 @@ float4 SSAOCalculate(VSOUT IN) : COLOR0
 
     packKey(CSZToKey(C.z), bilateralKey);
 
-    // Hash function used in the HPG12 AlchemyAO paper (Note from Boulotaur2024 : no hash in DX9 :/)
-	// float randomPatternRotationAngle = tex2D(noiseSampler, ssC*12.0).x * 1000.0;
-	//float randomPatternRotationAngle = (3 * ssC.x != ssC.y + ssC.x * ssC.y) * 10;
-	float randomPatternRotationAngle = random(ssC * 12) * 1000.0;	
+    // Hash function used in the HPG12 AlchemyAO paper
+	float randomPatternRotationAngle = noise1(ssC * float2(SCREEN_SIZE.x, SCREEN_SIZE.y)) * 1000.0; // McGuire noise function
+	//float randomPatternRotationAngle = random(ssC * 12) * 1000.0;
 
     // Reconstruct normals from positions. These will lead to 1-pixel black lines
     // at depth discontinuities, however the blur will wipe those out so they are not visible
@@ -391,7 +452,7 @@ float4 SSAOCalculate(VSOUT IN) : COLOR0
 	//return float4(n_C, 1.0);
 
     // Choose the screen-space sample radius
-    float ssDiskRadius = projScale * radius / max(C.z,0.1f);
+    float ssDiskRadius = -projScale * radius / max(C.z,0.1f);
 
     float sum = 0.0;
     for (int i = 0; i < NUM_SAMPLES; ++i) 
@@ -402,7 +463,12 @@ float4 SSAOCalculate(VSOUT IN) : COLOR0
     const float temp = radius2 * radius;
     sum /= temp * temp;
 
-    float A = max(0.0f, 1.0f - sum * intensity * (5.0f / NUM_SAMPLES));
+	#ifdef HIGH_QUALITY
+		// Addition from http://graphics.cs.williams.edu/papers/DeepGBuffer13/
+		float A = pow(max(0.0, 1.0 - sqrt(sum * (3.0 / NUM_SAMPLES))), intensity);
+	#else
+		float A = max(0.0f, 1.0f - sum * intensityDivR6 * (5.0f / NUM_SAMPLES));
+	#endif
 
 	// Bilateral box-filter over a quad for free, respecting depth edges
 	// (the difference that this makes is subtle)
@@ -413,6 +479,9 @@ float4 SSAOCalculate(VSOUT IN) : COLOR0
 		A -= ddy(A) * (((ssC.y - floor(ssC.y)) * 2) - 0.5);
 	}
 
+	// Anti-tone map to reduce contrast and drag dark region farther
+	// (x^0.2 + 1.2 * x^4)/2.2
+	A = (pow(A, 0.2) + 1.2 * A*A*A*A) / 2.2;
 	visibility = lerp(1.0, A, aoClamp);
 	//return float4(visibility, visibility, visibility, 1.0);
 	
@@ -438,8 +507,8 @@ the same blur shader to be used on different kinds of input data. */
 static const float gaussian[] =
 //	{ 0.356642, 0.239400, 0.072410, 0.009869 };
 //	{ 0.398943, 0.241971, 0.053991, 0.004432, 0.000134 };  // stddev = 1.0
-//    { 0.153170, 0.144893, 0.122649, 0.092902, 0.062970 };  // stddev = 2.0
-{ 0.111220, 0.107798, 0.098151, 0.083953, 0.067458, 0.050920, 0.036108 }; // stddev = 3.0
+//  { 0.153170, 0.144893, 0.122649, 0.092902, 0.062970 };  // stddev = 2.0
+  { 0.111220, 0.107798, 0.098151, 0.083953, 0.067458, 0.050920, 0.036108 }; // stddev = 3.0
 
 #define  result         output.VALUE_COMPONENTS
 #define  keyPassThrough output.KEY_COMPONENTS
@@ -450,43 +519,43 @@ float4 BlurBL(VSOUT IN) : COLOR0
 
 	float2 ssC = IN.UVCoord;
 
-	float4 temp = tex2Dlod(passSampler, float4(ssC,0,0));
+	float4 temp = tex2D(passSampler, ssC);
 
-	keyPassThrough = temp.KEY_COMPONENTS;
-	float key = unpackKey(keyPassThrough);
+    keyPassThrough = temp.KEY_COMPONENTS;
+    float key = unpackKey(keyPassThrough);
 
-	float sum = temp.r;
+	float sum = temp.VALUE_COMPONENTS;
 
-	if (key >= 0.999) { 
-		// Sky pixel (if you aren't using depth keying, disable this test)
-		result = sum;
-		return output;
-	}
+	[branch]
+    if (key >= 0.999) {
+        // Sky pixel (if you aren't using depth keying, disable this test)
+        result = sum;
+        return output;
+    }
 
 	// Base weight for depth falloff.  Increase this for more blurriness,
 	// decrease it for better edge discrimination
 	float BASE = gaussian[0];
 	float totalWeight = BASE;
-	sum *= totalWeight; 
+	sum *= totalWeight;
 
+	[unroll]
 	for (int r = -R; r <= R; ++r) {
 		// We already handled the zero case above.  This loop should be unrolled and the branch discarded
 		if (r != 0) {
             float2 axis = (isBlurHorizontal) ? float2(1, 0) : float2(0, 1);
+			temp = tex2D(passSampler, ssC + axis * PIXEL_SIZE * (r * SCALE));
+			float tapKey = unpackKey(temp.KEY_COMPONENTS);
+			float value  = temp.VALUE_COMPONENTS;
 
-			temp = tex2Dlod(passSampler, float4(ssC + axis * PIXEL_SIZE * (r * SCALE),0,0) );
-			float tapKey = unpackKey(temp.gb);
-			float value  = temp.r;
-
-			// spatial domain: offset gaussian tap
-			int index = r; if (index<0) index = -index;
-			float weight = 0.3 + gaussian[index];
-
+            // spatial domain: offset gaussian tap
+            float weight = 0.3 + gaussian[abs(r)];
+		
 			// range domain (the "bilateral" weight). As depth difference increases, decrease weight.
 			weight *= max(0.0, 1.0 - (2000.0 * EDGE_SHARPNESS) * abs(tapKey - key));
 
-			sum += value * weight;
-			totalWeight += weight;
+            sum += value * weight;
+            totalWeight += weight;
 		} 
 	}
 
@@ -500,9 +569,15 @@ float4 combine( VSOUT IN ) : COLOR0 {
 	float4 color = tex2D(frameSampler, IN.UVCoord);
 	float ao = tex2D(passSampler, IN.UVCoord).r;
 
+	#ifdef SHOW_DEPTH
+		nearZ = 0.1;
+		farZ = 1.0;
+		float depth = LinearizeDepth(tex2D(depthSampler, IN.UVCoord).r);
+		return float4(depth, depth, depth, 1.0);		
+	#endif
 	#ifdef SHOW_SSAO
-	return float4(ao,ao,ao,1);
-	#endif	
+		return float4(ao,ao,ao,1);
+	#endif
 	
 	#ifdef LUMINANCE_CONSIDERATION
 	float luminance = (color.r*0.2125f)+(color.g*0.7154f)+(color.b*0.0721f);
@@ -527,19 +602,14 @@ technique t0
 	pass p1
 	{
 		VertexShader = compile vs_3_0 FrameVS();
-		PixelShader = compile ps_3_0 downsamplePass();
+		PixelShader = compile ps_3_0 SSAOCalculate();
 	}
 	pass p2
 	{
 		VertexShader = compile vs_3_0 FrameVS();
-		PixelShader = compile ps_3_0 SSAOCalculate();
-	}
-	pass p3
-	{
-		VertexShader = compile vs_3_0 FrameVS();
 		PixelShader = compile ps_3_0 BlurBL();	
 	}
-	pass p4
+	pass p3
 	{
 		VertexShader = compile vs_3_0 FrameVS();
 		PixelShader = compile ps_3_0 combine();

--- a/pack/assets/dx9/martinsh_ssao.fx
+++ b/pack/assets/dx9/martinsh_ssao.fx
@@ -16,15 +16,15 @@ changelog:
 
 //make sure that these two values are the same for your camera, otherwise distances will be wrong.
 
-float nearZ = 0.001; //Z-near
-float farZ = 1.0; //Z-far
+float nearZ = 0.01; //Z-near
+float farZ = 30.0; //Z-far
 
 //user variables
 int samples = 8; //ao sample count
 
-float radius = 6.0; //ao radius
+float radius = 10.0; //ao radius
 float haloReduce = 0.26; //depth clamp - reduces haloing at screen edges
-bool noise = true; //use noise instead of pattern for sample dithering
+bool noise = false; //use noise instead of pattern for sample dithering
 float noiseamount = 0.0002; //dithering amount
 
 float diffarea = 0.4; //self-shadowing reduction
@@ -33,9 +33,6 @@ float gdisplace = 0.4; //gauss bell center
 bool mist = true; //use mist?
 float miststart = 0.0; //mist start
 float mistend = 16.0; //mist end
-
-bool onlyAO = true; //use only ambient occlusion pass?
-float lumInfluence = 0.0; //how much luminance affects occlusion
 
 extern float aoClamp = 0.0;
 

--- a/pack/config/AssassinsCreed_Dx9/GeDoSaTo.ini
+++ b/pack/config/AssassinsCreed_Dx9/GeDoSaTo.ini
@@ -9,3 +9,7 @@ modifyGetCursorPos true
 # HUDless
 injectPSHash ccc2791e
 injectDelayAfterDraw true
+
+# for SSAO (or DOF)
+zbufCompatibilityFlag 6
+zBufClearIndex 1

--- a/pack/config/GeDoSaTo.ini
+++ b/pack/config/GeDoSaTo.ini
@@ -85,8 +85,8 @@ overrideWidth 0
 overrideHeight 0
 
 # [GenericDepthPlugin] Zbuffer access compatibility flags (required for some reluctant games)
-# zbufCompatibilityFlag : bypasses d3d9 Clear flags (possible values: 2/3/6/7)
-# zBufClearIndex : delays the bypass by x number of iterations (usually 1/2/3 is fine)
+# zbufCompatibilityFlag : bypasses d3d9 Clear flags (possible values: 2/3/6/7) <-- try this first if no AO shows up
+# zBufClearIndex : delays the bypass by x number of iterations <-- to fix potential flickering / rendering issues
 zbufCompatibilityFlag 0
 zBufClearIndex 0
 
@@ -146,7 +146,7 @@ ssaoStrength 0
 # Set SSAO scale
 # 1 = high quality (default)
 # 2 = lower quality, lower impact on performance
-ssaoScale 1
+ssaoScale 2
 
 # Set SSAO Blur type
 # gaussian = soft, cheap

--- a/pack/config/MaxPayne/GeDoSaTo.ini
+++ b/pack/config/MaxPayne/GeDoSaTo.ini
@@ -1,0 +1,8 @@
+# Lines starting with "#" are ignored by GeDoSaTo and used to provide documentation
+# read them before changing anything!
+
+# Max Payne configuration
+
+# for SSAO (or DOF)
+zbufCompatibilityFlag 2
+zBufClearIndex 1

--- a/pack/config/TombRaider/GeDoSaTo.ini
+++ b/pack/config/TombRaider/GeDoSaTo.ini
@@ -1,0 +1,8 @@
+# Lines starting with "#" are ignored by GeDoSaTo and used to provide documentation
+# read them before changing anything!
+
+# Tomb Raider (DX9) configuration
+
+# for SSAO (or DOF)
+zbufCompatibilityFlag 6
+zBufClearIndex 0

--- a/source/plugins/dark_souls_2.cpp
+++ b/source/plugins/dark_souls_2.cpp
@@ -166,7 +166,7 @@ HRESULT DS2Plugin::redirectSetRenderState(D3DRENDERSTATETYPE State, DWORD Value)
 		frameTex = D3DGetSurfTexture(hdrRT);
 		if(depth && frameTex) {
 			SDLOG(2, "- AO ready to go\n")
-			ssao->goHDR(frameTex, depth, hdrRT);
+			ssao->goHDR(frameTex, depth, hdrRT, false);
 			SDLOG(2, "- AO done\n")
 		}
 		else {


### PR DESCRIPTION
Lotsa minor changes but the quality is great now :

. It now scales properly the depth texture for games like Dark Souls2 or RE Revelations for 16/10 users (isAspectRatioFixNeeded flag)
. The depth & ssao processing can be 1/2 scaled by the ssaoScale parameter in GeDoSaTo.ini
. Added a lot of comments to the SAO.fx shader itself and made some more settings configurable. I think it should be pretty readable even for non-hardcore users
. Mirror Edge and FFXIV still refuse to work with an injected depthstencil texture unfortunately. DeusEx HR -god I really wanted that one  to work but oh well- and FarCry 2 apparently have rendering issues with SSAO enabled (even if the SSAO works itself) but apart from that I'd say 8 out of 10 games work absolutely fine with injected SSAO, at least for me on a AMD card
