### PR TITLE
Mafia2 and CLOS2 configs

### DIFF
--- a/pack/config/CLOS2/GeDoSaTo.ini
+++ b/pack/config/CLOS2/GeDoSaTo.ini
@@ -1,0 +1,18 @@
+# Lines starting with "#" are ignored by GeDoSaTo and used to provide documentation
+
+# This is a profile file for CLOS2
+
+#  Resolution settings for screenshotting only. Must set same windowed resolution in game ini 
+#  and use SRWE to resize resulting window. Remove comment from following five lines to enable.
+#renderResolution 5760x3240@60
+#presentWidth 5760
+#presentHeight 3240
+#forceAlwaysDownsamplingRes true
+#forcePresentRes true
+
+# HUD removal - Works until City of the Dead
+injectPSHash 3de11d46
+
+# HUD removal - Works from City of the Dead
+#injectPSHash aa219b4c
+#injectDelayAfterDraw true

--- a/pack/config/Mafia2/GeDoSaTo.ini
+++ b/pack/config/Mafia2/GeDoSaTo.ini
@@ -1,0 +1,14 @@
+# Lines starting with "#" are ignored by GeDoSaTo and used to provide documentation
+
+# This is a profile file for Mafia2 
+
+#different AR's work
+maintainAspectRatio true
+
+#HUDless
+injectPSHash e841f15f
+
+loadSteamOverlayEarly true
+
+#At larger resolutions, full screen shots will give an error and fail. Below value may help to allow this to work the first time a shot is taken.
+maxScreenshotParallelism 4

--- a/pack/config/whitelist.txt
+++ b/pack/config/whitelist.txt
@@ -26,9 +26,9 @@ BLR                          || Blacklight: Retribution
 Borderlands                  || Borderlands
 Borderlands2                 || Borderlands 2
 bsnes                        || bsnes SNES emulator
-ShippingPC-StormGame         || Bulletstorm
 CastlevaniaLoSUE             || Castlevania: Lords of Shadow - Ultimate Edition
 ChildofLight                 || Child of Light
+CLOS2                        || Castlevania Lords of Shadow 2
 CMOF                         || Castlevania: Lords of Shadow - Mirror of Fate HD
 cnc3game.dat                 || Command & Conquer 3: Tiberium Wars
 Cognition Episode*           || Cognition: An Erica Reed Thriller
@@ -47,10 +47,10 @@ DarkSoulsII                  || Dark Souls 2
 DayZ                         || DayZ Standalone
 Dead Space                   || Dead Space
 demoniconR                   || Demonicon
-dmc3se                       || Devil May Cry 3 Special Edition
 DevilMayCry4_DX9             || Devil May Cry 4 (DX9)
 Diablo III                   || Diablo III
 Dishonored                   || Dishonored
+dmc3se                       || Devil May Cry 3 Special Edition
 DMC-DevilMayCry              || DmC Devil May Cry
 dota                         || Dota 2
 DragonAge2                   || Dragon Age 2
@@ -64,8 +64,8 @@ fear                         || F.E.A.R.
 FEAR2                        || F.E.A.R. 2
 FEARXP                       || F.E.A.R. Extraction Point
 FEARXP2                      || F.E.A.R. Perseus Mandate
-ffxiiiimg                    || Final Fantasy XIII
 ffxiii2img                   || Final Fantasy XIII-2
+ffxiiiimg                    || Final Fantasy XIII
 ffxiv                        || Final Fantasy XIV
 ffxiv*                       || Final Fantasy XIV Launcher or Configurator
 FirefallClient               || Firefall
@@ -98,6 +98,7 @@ left4dead2                   || Left 4 Dead 2
 LEGOMARVEL                   || LEGO Marvel Superheroes
 Leviathan                    || Leviathan: Warships
 LostPlanetDX9                || Lost Planet: Extreme Condition (DX9)
+Mafia2                       || Mafia II
 MassEffect                   || Mass Effect
 MassEffect2                  || Mass Effect 2
 MassEffect2Config            || Mass Effect 2 Configurator
@@ -135,6 +136,7 @@ Shadowrun                    || Shadowrun Returns
 Sherlock                     || Sherlock Holmes: Crimes and Punishments
 ShippingPC-BmGame            || Batman: Arkham Asylum GOTY
 ShippingPC-SkyGame           || Dark Void
+ShippingPC-StormGame         || Bulletstorm
 SkyrimLauncher               || The Elder Scrolls V: Skyrim Configurator
 SonicGenerations             || Sonic Generations
 SpaceMarine                  || SpaceMarine


### PR DESCRIPTION
Game specific configs including HUD removal. Specific instructions for screenshooting included.

Issues: 
Mafia2 - fullscreen screenshots at large resolutions at any AR usually fail with an error message.
CLOS2 - requires uncommenting some lines in the config and setting the render resolution in games ini file.