### PR TITLE
asmodean post-processing 1.65 updates

### DIFF
--- a/pack/assets/dx9/post_asmodean.fx
+++ b/pack/assets/dx9/post_asmodean.fx
@@ -250,18 +250,18 @@ float3 BlendOverlay(float3 color, float3 bloom)
 
 float4 PyramidFilter(sampler tex, float2 texcoord, float2 width)
 {
-    float4 color = tex2D(tex, texcoord + float2(0.5, 0.5) * width);
-    color += tex2D(tex, texcoord + float2(-0.5,  0.5) * width);
-    color += tex2D(tex, texcoord + float2(0.5, -0.5) * width);
-    color += tex2D(tex, texcoord + float2(-0.5, -0.5) * width);
-    color *= 0.25;
+    float4 X = tex2D(tex, texcoord + float2(0.5, 0.5) * width);
+    float4 Y = tex2D(tex, texcoord + float2(-0.5,  0.5) * width);
+    float4 Z = tex2D(tex, texcoord + float2(0.5, -0.5) * width);
+    float4 W = tex2D(tex, texcoord + float2(-0.5, -0.5) * width);
 
-    return color;
+    return (X + Y + Z + W) / 4.0;
 }
 
 float3 BloomCorrection(float3 color)
 {
     float3 bloom = (color.rgb - 0.5) * 2.0;
+
     bloom.r = 2.0 / 3.0 * (1.0 - (bloom.r * bloom.r));
     bloom.g = 2.0 / 3.0 * (1.0 - (bloom.g * bloom.g));
     bloom.b = 2.0 / 3.0 * (1.0 - (bloom.b * bloom.b));
@@ -269,6 +269,7 @@ float3 BloomCorrection(float3 color)
     bloom.r = saturate(color.r + BloomReds * bloom.r);
     bloom.g = saturate(color.g + BloomGreens * bloom.g);
     bloom.b = saturate(color.b + BloomBlues * bloom.b);
+
     color = bloom;
 
     return color;
@@ -276,10 +277,10 @@ float3 BloomCorrection(float3 color)
 
 float4 BloomPass(float4 color, float2 texcoord)
 {
-    float defocus = 1.25;
+    float defocus = 1.33;
     float anflare = 4.00;
 
-    float4 bloom = PyramidFilter(s0, texcoord, invDefocus * defocus);
+    float4 bloom = PyramidFilter(s0, texcoord, pixelSize * defocus);
 
     float2 dx = float2(invDefocus.x * float(BloomWidth), 0.0);
     float2 dy = float2(0.0, invDefocus.y * float(BloomWidth));

--- a/pack/assets/dx9/post_asmodean.fx
+++ b/pack/assets/dx9/post_asmodean.fx
@@ -1,5 +1,5 @@
 /*===============================================================================*\
-|########################    [GSFx Shader Suite v1.60]    ########################|
+|########################    [GSFx Shader Suite v1.65]    ########################|
 |##########################        By Asmodean          ##########################|
 ||                                                                               ||
 ||          This program is free software; you can redistribute it and/or        ||
@@ -35,7 +35,7 @@
 ------------------------------------------------------------------------------*/
 
 //##[BLOOM OPTIONS]##
-#define BloomType BlendGlow                 //[BlendGlow, BlendLuma, BlendAddLight, BlendScreen, BlendOverlay] The type of blending for the bloom.
+#define BloomType BlendAddGlow              //[BlendGlow, BlendAddGlow, BlendAddLight, BlendScreen, BlendLuma, BlendOverlay] The type of blended bloom.
 #define BloomStrength 0.220                 //[0.100 to 1.000] Overall strength of the bloom. You may want to readjust for each blend type.
 #define BlendStrength 1.000                 //[0.100 to 1.000] Strength of the bloom blend. Lower for less blending, higher for more. (Default: 1.000).
 #define BloomDefocus 2.200                  //[1.000 to 4.000] The initial bloom defocus value. Increases the softness of light, bright objects, etc.
@@ -59,7 +59,7 @@
 #define BlueCurve 1.00                      //[1.00 to 8.00] Blue channel component of the RGB correction curve. Higher values equals blue reduction. 1.00 is default.
 
 //##[FILMIC OPTIONS]##
-#define FilmicProcess 0                     //[0|1|2] Filmic cross processing. Alters the tone of the scene, for more of a filmic look. 0: off, 1|2: process type.
+#define FilmicProcess 1                     //[0|1|2] Filmic cross processing. Alters the tone of the scene, for more of a filmic look. 0: off, 1|2: process type.
 #define RedShift 0.50                       //[0.10 to 1.00] Red colour component shift of the filmic processing. Alters the red balance of the shift.
 #define GreenShift 0.45                     //[0.10 to 1.00] Green colour component shift of the filmic processing. Alters the green balance of the shift.
 #define BlueShift 0.45                      //[0.10 to 1.00] Blue colour component shift of the filmic processing. Alters the blue balance of the shift.
@@ -87,7 +87,7 @@
 #define Vibrance 0.20                       //[-1.00 to 1.00] Locally adjust the vibrance of pixels depending on their original saturation. 0.00 is original vibrance.
 
 //##[CONTRAST OPTIONS]##
-#define Contrast 0.35                       //[0.00 to 2.00] The amount of contrast you want. Controls the overall contrast strength.
+#define Contrast 0.30                       //[0.00 to 2.00] The amount of contrast you want. Controls the overall contrast strength.
 
 //[END OF USER OPTIONS]##
 
@@ -236,6 +236,13 @@ float3 BlendLuma(float3 bloom, float3 blend)
     ((1.0 - bloom) * (1.0 - blend))), lumavg);
 }
 
+float3 BlendAddGlow(float3 bloom, float3 blend)
+{
+    float glow = smoothstep(0.0, 1.0, AvgLuminance(bloom));
+    return lerp(saturate(bloom + blend),
+    (blend + blend) - (blend * blend), glow);
+}
+
 float3 BlendGlow(float3 bloom, float3 blend)
 {
     float glow = smoothstep(0.0, 1.0, AvgLuminance(bloom));
@@ -347,7 +354,10 @@ float3 FilmicALU(float3 color)
 
     tone = max(0, tone - 0.004);
     tone = (tone * (6.2 * tone + 0.5)) / (tone * (6.2 * tone + 1.7) + 0.06);
-    tone = pow(tone, gamma);
+
+    tone.r = pow(tone.r, gamma);
+    tone.g = pow(tone.g, gamma);
+    tone.b = pow(tone.b, gamma);
 
     return lerp(color, tone, float(ToneAmount) / 1.2);
 

--- a/pack/assets/dx9/post_asmodean.fx
+++ b/pack/assets/dx9/post_asmodean.fx
@@ -36,7 +36,7 @@
 
 //##[BLOOM OPTIONS]##
 #define BloomType BlendGlow                 //[BlendGlow, BlendLuma, BlendAddLight, BlendScreen, BlendOverlay] The type of blending for the bloom.
-#define BloomStrength 0.250                 //[0.100 to 1.000] Overall strength of the bloom. You may want to readjust for each blend type.
+#define BloomStrength 0.220                 //[0.100 to 1.000] Overall strength of the bloom. You may want to readjust for each blend type.
 #define BlendStrength 1.000                 //[0.100 to 1.000] Strength of the bloom blend. Lower for less blending, higher for more. (Default: 1.000).
 #define BloomWidth 4.000                    //[1.000 to 8.000] Width of the bloom 'glow' spread. Scales with BloomStrength. (Default: 4.000).
 #define BloomReds 1.00                      //[0.00 to 8.00] Red channel component of the RGB correction curve. Higher values equals red reduction. 1.00 is default.
@@ -44,12 +44,12 @@
 #define BloomBlues 1.00                     //[0.00 to 8.00] Blue channel component of the RGB correction curve. Higher values equals blue reduction. 1.00 is default.
 
 //##[TONEMAP OPTIONS]##
-#define TonemapType 1                       //[0|1|2] Type of base tone mapping operator. 0 is LDR, 1 is HDR(original), 2 is HDR filmic(palette alterations for more of a film style).
+#define TonemapType 2                       //[0|1|2] Type of base tone mapping operator. 0 is LDR, 1 is HDR(original), 2 is HDR filmic(palette alterations for more of a film style).
 #define ToneAmount 0.20                     //[0.00 to 1.00] Tonemap strength (scene correction) higher for stronger tone mapping, lower for lighter. (Default: ~ 0.20)
-#define BlackLevels 0.08                    //[0.00 to 1.00] Black level balance (shadow correction). Increase to deepen blacks, lower to lighten them. (Default: ~ 0.10)
+#define BlackLevels 0.06                    //[0.00 to 1.00] Black level balance (shadow correction). Increase to deepen blacks, lower to lighten them. (Default: ~ 0.10)
 #define Exposure 1.00                       //[0.10 to 2.00] White correction (brightness) Higher values for more Exposure, lower for less.
 #define Luminance 1.02                      //[0.10 to 2.00] Luminance average (luminance correction) Higher values to decrease luminance average, lower values to increase luminance.
-#define WhitePoint 1.02                     //[0.10 to 2.00] Whitepoint avg (lum correction) Use to alter the scene whitepoint average. Raising can give a cinema look.
+#define WhitePoint 1.02                     //[0.10 to 2.00] Whitepoint average (lum correction). The actual white point is handled by the tone map logic. This is just an offset value.
 
 //##[CORRECTION OPTIONS]##
 #define CorrectionPalette 1                 //[0|1|2|3] The colour correction palette type. 1: RGB, 2: YUV, 3: XYZ, 0: off. 1 is default. This requires tone mapping enabled.
@@ -58,11 +58,11 @@
 #define BlueCurve 1.00                      //[1.00 to 8.00] Blue channel component of the RGB correction curve. Higher values equals blue reduction. 1.00 is default.
 
 //##[FILMIC OPTIONS]##
-#define FilmicProcess 0                     //[0 or 1] Filmic cross processing. Alters the mood of the scene, for more of a filmic look. Typically best suited to realistic style games.
-#define RedShift 0.50                       //[0.10 to 1.00] Red colour component shift of the filmic tone shift. Alters the red balance of the shift. Requires FilmicProcess.
-#define GreenShift 0.45                     //[0.10 to 1.00] Green colour component shift of the filmic tone shift. Alters the green balance of the shift. Requires FilmicProcess.
-#define BlueShift 0.45                      //[0.10 to 1.00] Blue colour component shift of the filmic tone shift. Alters the blue balance of the shift. Requires FilmicProcess.
-#define ShiftRatio 0.28                     //[0.10 to 1.00] The blending ratio for the base colour and the colour shift. Higher for a stronger effect. Requires FilmicProcess.
+#define FilmicProcess 1                     //[0|1|2] Filmic cross processing. Alters the tone of the scene, for more of a filmic look. 0: off, 1|2: process type.
+#define RedShift 0.50                       //[0.10 to 1.00] Red colour component shift of the filmic processing. Alters the red balance of the shift.
+#define GreenShift 0.45                     //[0.10 to 1.00] Green colour component shift of the filmic processing. Alters the green balance of the shift.
+#define BlueShift 0.45                      //[0.10 to 1.00] Blue colour component shift of the filmic processing. Alters the blue balance of the shift.
+#define ShiftRatio 0.33                     //[0.10 to 1.00] The blending ratio for the base colour and the colour shift. Higher for a stronger effect. 
 
 //##[SHARPEN OPTIONS]##
 #define SharpenStrength 0.75                //[0.10 to 1.00] Strength of the texture sharpening effect. This is the maximum strength that will be used.
@@ -71,7 +71,7 @@
 #define DebugSharpen 0                      //[0 or 1] Visualize the sharpening effect. Useful for fine-tuning. Best to disable other effects, to see edge detection clearly.
 
 //##[CSHADE OPTIONS]##
-#define EdgeStrength 1.50                   //[0.00 to 4.00] Overall strength of the cel edge outline effect.  0.00 = no outlines.
+#define EdgeStrength 1.50                   //[0.00 to 4.00] Overall strength of the cel edge outline effect.  0.00: no outlines.
 #define EdgeFilter 0.60                     //[0.10 to 2.00] Filters out fainter cel edges. Use it for balancing the cel edge density. EG: for faces, foliage, etc. Raise to filter out more edges.
 #define EdgeThickness 1.00                  //[0.50 to 4.00] Thickness of the cel edges. Increase for thicker outlining.  Note: when downsampling, you may need to raise this further to keep the edges as noticeable.
 #define PaletteType 2                       //[1|2|3] The colour palette to use. 1 is Game Original, 2 is Animated Shading, 3 is Water Painting (Default is 2: Animated Shading). #!Options below don't affect palette 1.
@@ -83,7 +83,7 @@
 #define Gamma 2.20                          //[1.5 to 4.0] Gamma correction. Decrease for lower gamma(darker). Increase for higher gamma(brighter). (Default: 2.2)
 
 //##[VIBRANCE OPTIONS]##
-#define Vibrance 0.10                       //[-1.00 to 1.00] Adjust the vibrance of pixels depending on their original saturation. 0.00 is original vibrance.
+#define Vibrance 0.20                       //[-1.00 to 1.00] Locally adjust the vibrance of pixels depending on their original saturation. 0.00 is original vibrance.
 
 //##[CONTRAST OPTIONS]##
 #define Contrast 0.35                       //[0.00 to 2.00] The amount of contrast you want. Controls the overall contrast strength.
@@ -103,8 +103,8 @@ static float2 screenSize = SCREEN_SIZE;
 static float2 invDefocus = float2(1.0 / 3840.0, 1.0 / 2160.0);
 static const float3 lumCoeff = float3(0.2126729, 0.7151522, 0.0721750);
 
-Texture2D thisframeTex;
-SamplerState s0
+texture thisframeTex;
+sampler s0
 {
     Texture = <thisframeTex>;
     MinFilter = Linear;
@@ -112,6 +112,7 @@ SamplerState s0
     MipFilter = Linear;
     AddressU = Clamp;
     AddressV = Clamp;
+    MaxAnisotropy = 16;
     SRGBTexture = USE_SRGB;
 };
 
@@ -132,11 +133,6 @@ struct PS_OUTPUT
     float4 color : COLOR0;
 };
 
-float RGBLuminance(float3 color)
-{
-    return dot(color.xyz, lumCoeff);
-}
-
 float AvgLuminance(float3 color)
 {
     return sqrt((color.x * color.x * lumCoeff.x) +
@@ -154,7 +150,11 @@ float4 DebugClipping(float4 color)
 
     return color;
 }
-*/
+
+float RGBLuminance(float3 color)
+{
+    return dot(color.xyz, lumCoeff);
+}*/
 
 
 /*------------------------------------------------------------------------------
@@ -176,7 +176,7 @@ VS_OUTPUT FrameVS(VS_INPUT Input)
 ------------------------------------------------------------------------------*/
 
 #if (GAMMA_CORRECTION == 1)
-float3 RGBGammaToLinear(in float3 color, in float gamma)
+float3 RGBGammaToLinear(float3 color, float gamma)
 {
     color = saturate(color);
     color.r = (color.r <= 0.0404482362771082) ?
@@ -189,7 +189,7 @@ float3 RGBGammaToLinear(in float3 color, in float gamma)
     return color;
 }
 
-float3 LinearToRGBGamma(in float3 color, in float gamma)
+float3 LinearToRGBGamma(float3 color, float gamma)
 {
     color = saturate(color);
     color.r = (color.r <= 0.00313066844250063) ?
@@ -218,29 +218,29 @@ float4 GammaPass(float4 color, float2 texcoord)
 ------------------------------------------------------------------------------*/
 
 #if (BLENDED_BLOOM == 1)
-float3 BlendAddLight(in float3 color, in float3 bloom)
+float3 BlendAddLight(float3 color, float3 bloom)
 {
     return saturate(color + bloom);
 }
 
-float3 BlendScreen(in float3 color, in float3 bloom)
+float3 BlendScreen(float3 color, float3 bloom)
 {
     return (color + bloom) - (color * bloom);
 }
 
-float3 BlendLuma(in float3 color, in float3 bloom)
+float3 BlendLuma(float3 color, float3 bloom)
 {
     float lumavg = AvgLuminance(color + bloom);
     return lerp((color * bloom), (1.0 - ((1.0 - color) * (1.0 - bloom))), lumavg);
 }
 
-float3 BlendGlow(in float3 color, in float3 bloom)
+float3 BlendGlow(float3 color, float3 bloom)
 {
-    float glow = smoothstep(0.0, 1.0, AvgLuminance(color.rgb));
+    float glow = smoothstep(0.0, 1.0, AvgLuminance(color));
     return lerp((color + bloom) - (color * bloom), (bloom + bloom) - (bloom * bloom), glow);
 }
 
-float3 BlendOverlay(in float3 color, in float3 bloom)
+float3 BlendOverlay(float3 color, float3 bloom)
 {
     float3 overlay = step(0.5, color);
     overlay = lerp((color * bloom * 2.0), (1.0 - (2.0 * (1.0 - color) * (1.0 - bloom))), overlay);
@@ -248,7 +248,7 @@ float3 BlendOverlay(in float3 color, in float3 bloom)
     return overlay;
 }
 
-float4 PyramidFilter(in sampler2D tex, in float2 texcoord, in float2 width)
+float4 PyramidFilter(sampler tex, float2 texcoord, float2 width)
 {
     float4 color = tex2D(tex, texcoord + float2(0.5, 0.5) * width);
     color += tex2D(tex, texcoord + float2(-0.5,  0.5) * width);
@@ -259,7 +259,7 @@ float4 PyramidFilter(in sampler2D tex, in float2 texcoord, in float2 width)
     return color;
 }
 
-float3 BloomCorrection(in float3 color)
+float3 BloomCorrection(float3 color)
 {
     float X = 1.0 / (1.0 + exp(float(BloomReds) / 2.0));
     float Y = 1.0 / (1.0 + exp(float(BloomGreens) / 2.0));
@@ -317,11 +317,11 @@ float4 BloomPass(float4 color, float2 texcoord)
     bloomBlend += 0.002589001911021066 * tex2D(s0, texcoord + mdx - mdy);
     bloomBlend = lerp(color, bloomBlend, float(BlendStrength));
 
-    bloom.rgb = BloomType(bloom.rgb, bloomBlend.rgb);
-    bloom.rgb = BloomCorrection(bloom.rgb);
+    bloom.xyz = BloomType(bloom.xyz, bloomBlend.xyz);
+    bloom.xyz = BloomCorrection(bloom.xyz);
 
-    color.a = AvgLuminance(color.rgb);
-    bloom.a = AvgLuminance(bloom.rgb);
+    color.a = AvgLuminance(color.xyz);
+    bloom.a = AvgLuminance(bloom.xyz);
     bloom.a *= anflare;
 
     color = lerp(color, bloom, float(BloomStrength));
@@ -335,7 +335,7 @@ float4 BloomPass(float4 color, float2 texcoord)
 ------------------------------------------------------------------------------*/
 
 #if (SCENE_TONEMAPPING == 1)
-float4 ScaleBlk(in float4 color)
+float4 ScaleBlk(float4 color)
 {
     color = float4(color.rgb * pow(abs(max(color.r,
     max(color.g, color.b))), float(BlackLevels)), color.a);
@@ -343,16 +343,17 @@ float4 ScaleBlk(in float4 color)
     return color;
 }
 
-float3 FilmicTonemap(in float3 color)
+float3 FilmicCurve(float3 color)
 {
+    float delta = 0.001;
     float3 Q = color.xyz;
 
     float A = 0.10;
     float B = 0.30;
     float C = 0.10;
     float D = float(ToneAmount);
-    float E = 0.02;
-    float F = 0.30;
+    float E = 0.02 + delta;
+    float F = 0.33;
     float W = float(WhitePoint);
 
     float3 numerator = ((Q*(A*Q + C*B) + D*E) / (Q*(A*Q + B) + D*F)) - E / F;
@@ -363,28 +364,28 @@ float3 FilmicTonemap(in float3 color)
     return saturate(color);
 }
 
-float3 CrossShift(in float3 color)
+float3 CrossShift(float3 color)
 {
-    float3 colMood;
+    float3 cross;
 
     float2 CrossMatrix[3] = {
     float2 (0.96, 0.04),
     float2 (0.99, 0.01),
     float2 (0.97, 0.03), };
 
-    colMood.r = float(RedShift) * CrossMatrix[0].x + CrossMatrix[0].y;
-    colMood.g = float(GreenShift) * CrossMatrix[1].x + CrossMatrix[1].y;
-    colMood.b = float(BlueShift) * CrossMatrix[2].x + CrossMatrix[2].y;
+    cross.r = float(RedShift) * CrossMatrix[0].x + CrossMatrix[0].y;
+    cross.g = float(GreenShift) * CrossMatrix[1].x + CrossMatrix[1].y;
+    cross.b = float(BlueShift) * CrossMatrix[2].x + CrossMatrix[2].y;
 
-    float fLum = AvgLuminance(color.xyz);
-    colMood = lerp(0.0, colMood, saturate(fLum * 2.0));
-    colMood = lerp(colMood, 1.0, saturate(fLum - 0.5) * 2.0);
-    float3 colOutput = lerp(color, colMood, saturate(fLum * float(ShiftRatio)));
+    float lum = AvgLuminance(color);
+    cross = lerp(0.0, cross, saturate(lum * 2.0));
+    cross = lerp(cross, 1.0, saturate(lum - 0.5) * 2.0);
+    color = lerp(color, cross, saturate(lum * float(ShiftRatio)));
 
-    return colOutput;
+    return color;
 }
 
-float3 ColorCorrection(in float3 color)
+float3 ColorCorrection(float3 color)
 {
     float X = 1.0 / (1.0 + exp(float(RedCurve) / 2.0));
     float Y = 1.0 / (1.0 + exp(float(GreenCurve) / 2.0));
@@ -400,13 +401,14 @@ float3 ColorCorrection(in float3 color)
 float4 TonemapPass(float4 color, float2 texcoord)
 {
     const float delta = 0.001;
-    const float wpoint = pow(1.002, 2.0);
+    float wpoint = max(color.x, max(color.y, color.z));
+    wpoint = wpoint / wpoint;
     
     color = ScaleBlk(color);
 
     if (CorrectionPalette == 1) { color.rgb = ColorCorrection(color.rgb); }
     if (FilmicProcess == 1) { color.rgb = CrossShift(color.rgb); }
-    if (TonemapType == 1) { color.rgb = FilmicTonemap(color.rgb); }
+    if (TonemapType == 1) { color.rgb = FilmicCurve(color.rgb); }
 
     // RGB -> XYZ conversion
     static const float3x3 RGB2XYZ = { 0.4124564, 0.3575761, 0.1804375,
@@ -422,8 +424,8 @@ float4 TonemapPass(float4 color, float2 texcoord)
     Yxy.g = XYZ.r / (XYZ.r + XYZ.g + XYZ.b);    // x = X / (X + Y + Z)
     Yxy.b = XYZ.g / (XYZ.r + XYZ.g + XYZ.b);    // y = Y / (X + Y + Z)
 
-    if (CorrectionPalette == 2) { Yxy.rgb = ColorCorrection(Yxy.rgb); }
-    if (TonemapType == 2) { Yxy.r = FilmicTonemap(Yxy.rgb).r; }
+    if (CorrectionPalette == 2) { Yxy = ColorCorrection(Yxy); }
+    if (TonemapType == 2) { Yxy.r = FilmicCurve(Yxy).r; }
 
     // (Lp) Map average luminance to the middlegrey zone by scaling pixel luminance
     float Lp = Yxy.r * float(Exposure) / (float(Luminance) + delta);
@@ -436,7 +438,8 @@ float4 TonemapPass(float4 color, float2 texcoord)
     XYZ.g = Yxy.r;                                  // copy luminance Y
     XYZ.b = Yxy.r * (1.0 - Yxy.g - Yxy.b) / Yxy.b;  // Z = Y * (1-x-y) / y
 
-    if (CorrectionPalette == 3) { XYZ.rgb = ColorCorrection(XYZ.rgb); }
+    if (CorrectionPalette == 3) { XYZ = ColorCorrection(XYZ); }
+    if (FilmicProcess == 2) { XYZ = CrossShift(XYZ); }
 
     // XYZ -> RGB conversion
     static const float3x3 XYZ2RGB = { 3.2404542,-1.5371385,-0.4985314,
@@ -468,7 +471,7 @@ float Cubic(float coeff)
     return (x + y + z + w) / 4.0;
 }
 
-float4 SampleBicubic(in SamplerState texSample, in float2 TexCoord)
+float4 SampleBicubic(sampler texSample, float2 TexCoord)
 {
     float texelSizeX = pixelSize.x * float(SharpenBias);
     float texelSizeY = pixelSize.y * float(SharpenBias);
@@ -532,7 +535,7 @@ float4 TexSharpenPass(float4 color, float2 texcoord)
 #if (CEL_SHADING == 1)
 float3 GetYUV(float3 RGB)
 {
-    const float3x3 RGB2YUV = {
+    static const float3x3 RGB2YUV = {
     0.2126, 0.7152, 0.0722,
    -0.09991,-0.33609, 0.436,
     0.615, -0.55861, -0.05639 };
@@ -542,7 +545,7 @@ float3 GetYUV(float3 RGB)
 
 float3 GetRGB(float3 YUV)
 {
-    const float3x3 YUV2RGB = {
+    static const float3x3 YUV2RGB = {
     1.000, 0.000, 1.28033,
     1.000,-0.21482,-0.38059,
     1.000, 2.12798, 0.000 };
@@ -609,7 +612,7 @@ float4 CelPass(float4 color, float2 uv0)
     #if (PaletteType == 1)
         color.rgb = lerp(color.rgb, color.rgb + pow(edge, EdgeFilter) * -EdgeStrength, EdgeStrength);
     #elif (PaletteType == 2)
-        color.rgb = lerp(color.rgb + pow(edge, EdgeFilter) * -EdgeStrength, shadedColor, 0.30);
+        color.rgb = lerp(color.rgb + pow(edge, EdgeFilter) * -EdgeStrength, shadedColor, 0.25);
     #elif (PaletteType == 3)
         color.rgb = lerp(shadedColor + edge * -EdgeStrength, pow(edge, EdgeFilter) * -EdgeStrength + color.rgb, 0.5);
     #endif
@@ -732,6 +735,7 @@ technique t0
         PixelShader = compile ps_3_0 postProcessing();
         ZEnable = false;
         CullMode = NONE;
+        ShadeMode = Phong;
         AlphaBlendEnable = false;
         AlphaTestEnable = false;
         SRGBWriteEnable = USE_SRGB;

--- a/pack/assets/dx9/post_asmodean.fx
+++ b/pack/assets/dx9/post_asmodean.fx
@@ -401,8 +401,7 @@ float3 ColorCorrection(float3 color)
 float4 TonemapPass(float4 color, float2 texcoord)
 {
     const float delta = 0.001;
-    float wpoint = max(color.x, max(color.y, color.z));
-    wpoint = wpoint / wpoint;
+    float wpoint = max(color.x, max(color.y, color.z)); wpoint /= wpoint;
     
     color = ScaleBlk(color);
 


### PR DESCRIPTION
* Resolved a tiny amount of clipping, introduced in the previous update. My tone mapping not only causes no clipping, but It can also reduce or completely resolve both high and low clipping from the default game. Example: The game I'm currently playing (The Witcher 2) has terrible clipping of both blacks and whites by default. My tone mapping resolves both.
* Removed input arguments (from compiler test), that I'd forgotten about.
* Added a new bloom type to choose from.
* Added new bloom-exclusive colour correction, and a defocus option.
* Improved bloom soft lighting.
* Improvements to tone mapping, and added a new tonemap operator type(HDR Filmic ALU) to the existing options.
* Added a new cross processing palette type to choose.
* Updated some options, and their descriptions, to reflect changes.

Comparison with demo settings;
Off: https://farm8.staticflickr.com/7339/16595661151_535684c2c3_o.png
On: https://farm8.staticflickr.com/7437/16596219552_f7de5f3abc_o.png
