### PR TITLE
Update post_asmodean to 1.70

### DIFF
--- a/pack/assets/dx9/post_asmodean.fx
+++ b/pack/assets/dx9/post_asmodean.fx
@@ -61,7 +61,7 @@
 //##[FILMIC OPTIONS]##
 #define FilmicProcess 0                     //[0|1|2] Filmic cross processing. Alters the tone of the scene, for more of a filmic look. 0: off, 1|2: process type.
 #define RedShift 0.50                       //[0.10 to 1.00] Red colour component shift of the filmic processing. Alters the red balance of the shift.
-#define GreenShift 0.45                     //[0.10 to 1.00] Green colour component shift of the filmic processing. Alters the green balance of the shift.
+#define GreenShift 0.46                     //[0.10 to 1.00] Green colour component shift of the filmic processing. Alters the green balance of the shift.
 #define BlueShift 0.45                      //[0.10 to 1.00] Blue colour component shift of the filmic processing. Alters the blue balance of the shift.
 #define ShiftRatio 0.25                     //[0.10 to 1.00] The blending ratio for the base colour and the colour shift. Higher for a stronger effect. 
 
@@ -293,7 +293,7 @@ float3 BloomCorrection(float3 color)
 float4 BloomPass(float4 color, float2 texcoord)
 {
     float anflare = 4.00;
-    float defocus = float(BloomDefocus);
+    float defocus = BloomDefocus;
 
     float4 bloom = PyramidFilter(s0, texcoord, pixelSize * defocus);
 
@@ -359,13 +359,15 @@ float3 FilmicALU(float3 color)
     static const float gamma = 2.233;
 
     tone = max(0, tone - 0.004);
-    tone = (tone * (6.2 * tone + 0.5)) / (tone * (6.2 * tone + 1.7) + 0.06);
+    tone = (tone * (6.2 * tone + 0.5)) / (tone * (6.2 * tone + 1.7) + 0.066);
 
     tone.r = pow(tone.r, gamma);
     tone.g = pow(tone.g, gamma);
     tone.b = pow(tone.b, gamma);
 
-    return lerp(color, tone, float(ToneAmount));
+    color = lerp(color, tone, float(ToneAmount));
+
+    return color;
 
 }
 

--- a/pack/assets/dx9/post_asmodean.fx
+++ b/pack/assets/dx9/post_asmodean.fx
@@ -365,7 +365,7 @@ float3 FilmicALU(float3 color)
     tone.g = pow(tone.g, gamma);
     tone.b = pow(tone.b, gamma);
 
-    return lerp(color, tone, float(ToneAmount) / 1.2);
+    return lerp(color, tone, float(ToneAmount));
 
 }
 

--- a/pack/assets/dx9/post_asmodean.fx
+++ b/pack/assets/dx9/post_asmodean.fx
@@ -394,17 +394,20 @@ float3 CrossShift(float3 color)
     float3 cross;
 
     float2 CrossMatrix[3] = {
-    float2 (0.96, 0.04),
-    float2 (0.99, 0.01),
-    float2 (0.97, 0.03), };
+    float2 (0.96, 0.04 * color.r),
+    float2 (0.98, 0.02 * color.g),
+    float2 (0.97, 0.03 * color.b), };
 
     cross.r = float(RedShift) * CrossMatrix[0].x + CrossMatrix[0].y;
     cross.g = float(GreenShift) * CrossMatrix[1].x + CrossMatrix[1].y;
     cross.b = float(BlueShift) * CrossMatrix[2].x + CrossMatrix[2].y;
 
     float lum = AvgLuminance(color);
-    cross = lerp(0.0, cross, saturate(lum * 2.0));
-    cross = lerp(cross, 1.0, saturate(lum - 0.5) * 2.0);
+    float3 black = float3(0.0, 0.0, 0.0);
+    float3 white = float3(1.0, 1.0, 1.0);
+
+    cross = lerp(black, cross, saturate(lum * 2.0));
+    cross = lerp(cross, white, saturate(lum - 0.5) * 2.0);
     color = lerp(color, cross, saturate(lum * float(ShiftRatio)));
 
     return color;
@@ -427,7 +430,9 @@ float4 TonemapPass(float4 color, float2 texcoord)
 {
     float avgluminance = AvgLuminance(Luminance);
     float wpoint = max(color.r, max(color.g, color.b)); wpoint /= wpoint;
-    color.rgb *= pow(saturate(max(color.r, max(color.g, color.b))), float(BlackLevels));
+
+    float blevel = pow(saturate(max(color.r, max(color.g, color.b))), float(BlackLevels));
+    color.rgb = color.rgb * blevel;
 
     if (TonemapType == 2) { color.rgb = FilmicALU(color.rgb); }
     if (FilmicProcess == 1) { color.rgb = CrossShift(color.rgb); }

--- a/pack/assets/dx9/post_asmodean.fx
+++ b/pack/assets/dx9/post_asmodean.fx
@@ -1,5 +1,5 @@
 /*===============================================================================*\
-|########################    [GSFx Shader Suite v1.60]    ########################|
+|########################    [GSFx Shader Suite v1.65]    ########################|
 |##########################        By Asmodean          ##########################|
 ||                                                                               ||
 ||          This program is free software; you can redistribute it and/or        ||
@@ -10,7 +10,7 @@
 ||          This program is distributed in the hope that it will be useful,      ||
 ||          but WITHOUT ANY WARRANTY; without even the implied warranty of       ||
 ||          MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the        ||
-||          GNU General Public License for more details. (c)2014                 ||
+||          GNU General Public License for more details. (c)2015                 ||
 ||                                                                               ||
 |#################################################################################|
 \*===============================================================================*/
@@ -35,34 +35,35 @@
 ------------------------------------------------------------------------------*/
 
 //##[BLOOM OPTIONS]##
-#define BloomType BlendGlow                 //[BlendGlow, BlendLuma, BlendAddLight, BlendScreen, BlendOverlay] The type of blending for the bloom.
-#define BloomStrength 0.250                 //[0.100 to 1.000] Overall strength of the bloom. You may want to readjust for each blend type.
+#define BloomType BlendAddGlow              //[BlendGlow, BlendAddGlow, BlendAddLight, BlendScreen, BlendLuma, BlendOverlay] The type of blended bloom.
+#define BloomStrength 0.220                 //[0.100 to 1.000] Overall strength of the bloom. You may want to readjust for each blend type.
 #define BlendStrength 1.000                 //[0.100 to 1.000] Strength of the bloom blend. Lower for less blending, higher for more. (Default: 1.000).
-#define BloomWidth 4.000                    //[1.000 to 8.000] Width of the bloom 'glow' spread. Scales with BloomStrength. (Default: 4.000).
-#define BloomReds 1.00                      //[0.00 to 8.00] Red channel component of the RGB correction curve. Higher values equals red reduction. 1.00 is default.
-#define BloomGreens 1.00                    //[0.00 to 8.00] Green channel component of the RGB correction curve. Higher values equals green reduction. 1.00 is default.
-#define BloomBlues 1.00                     //[0.00 to 8.00] Blue channel component of the RGB correction curve. Higher values equals blue reduction. 1.00 is default.
+#define BloomDefocus 2.200                  //[1.000 to 4.000] The initial bloom defocus value. Increases the softness of light, bright objects, etc.
+#define BloomWidth 4.000                    //[1.000 to 8.000] Width of the bloom 'soft glow' spread. Scales with BloomStrength. (Default: 4.000).
+#define BloomReds 0.010                     //[0.000 to 1.000] Bloom-exclusive colour correction of the red channel. Adjust for desired manipulation of reds.
+#define BloomGreens 0.005                   //[0.000 to 1.000] Bloom-exclusive colour correction of the green channel. Adjust for desired manipulation of greens.
+#define BloomBlues 0.005                    //[0.000 to 1.000] Bloom-exclusive colour correction of the blue channel. Adjust for desired manipulation of blues.
 
 //##[TONEMAP OPTIONS]##
-#define TonemapType 1                       //[0|1|2] Type of base tone mapping operator. 0 is LDR, 1 is HDR(original), 2 is HDR filmic(palette alterations for more of a film style).
-#define ToneAmount 0.20                     //[0.00 to 1.00] Tonemap strength (scene correction) higher for stronger tone mapping, lower for lighter. (Default: ~ 0.20)
-#define BlackLevels 0.08                    //[0.00 to 1.00] Black level balance (shadow correction). Increase to deepen blacks, lower to lighten them. (Default: ~ 0.10)
-#define Exposure 1.00                       //[0.10 to 2.00] White correction (brightness) Higher values for more Exposure, lower for less.
+#define TonemapType 2                       //[0|1|2] Type of base tone mapping operator. 0 is LDR, 1 is HDR(original), 2 is HDR Filmic ALU(cinematic).
+#define ToneAmount 0.20                     //[0.00 to 1.00] Tonemap strength (scene correction) higher for stronger tone mapping, lower for lighter.
+#define BlackLevels 0.05                    //[0.00 to 1.00] Black level balance (shadow correction). Increase to deepen blacks, lower to lighten them.
+#define Exposure 1.00                       //[0.10 to 2.00] White correction (brightness) Higher values for more scene exposure, lower for less.
 #define Luminance 1.02                      //[0.10 to 2.00] Luminance average (luminance correction) Higher values to decrease luminance average, lower values to increase luminance.
-#define WhitePoint 1.02                     //[0.10 to 2.00] Whitepoint avg (lum correction) Use to alter the scene whitepoint average. Raising can give a cinema look.
+#define WhitePoint 1.02                     //[0.10 to 2.00] Whitepoint average (lum correction). The actual white point is handled by the tone map logic. This is just an offset value.
 
 //##[CORRECTION OPTIONS]##
-#define CorrectionPalette 1                 //[0|1|2|3] The colour correction palette type. 1: RGB, 2: YUV, 3: XYZ, 0: off. 1 is default. This requires tone mapping enabled.
-#define RedCurve 1.00                       //[1.00 to 8.00] Red channel component of the RGB correction curve. Higher values equals red reduction. 1.00 is default.
-#define GreenCurve 1.00                     //[1.00 to 8.00] Green channel component of the RGB correction curve. Higher values equals green reduction. 1.00 is default.
-#define BlueCurve 1.00                      //[1.00 to 8.00] Blue channel component of the RGB correction curve. Higher values equals blue reduction. 1.00 is default.
+#define CorrectionPalette 3                 //[0|1|2|3] The colour correction palette type. 1: RGB, 2: YUV, 3: XYZ, 0: off. 1 is default. This requires tone mapping enabled.
+#define RedCurve 1.25                       //[1.00 to 8.00] Red channel component of the RGB correction curve. Higher values equals red reduction. 1.00 is default.
+#define GreenCurve 1.25                     //[1.00 to 8.00] Green channel component of the RGB correction curve. Higher values equals green reduction. 1.00 is default.
+#define BlueCurve 1.25                      //[1.00 to 8.00] Blue channel component of the RGB correction curve. Higher values equals blue reduction. 1.00 is default.
 
 //##[FILMIC OPTIONS]##
-#define FilmicProcess 0                     //[0 or 1] Filmic cross processing. Alters the mood of the scene, for more of a filmic look. Typically best suited to realistic style games.
-#define RedShift 0.50                       //[0.10 to 1.00] Red colour component shift of the filmic tone shift. Alters the red balance of the shift. Requires FilmicProcess.
-#define GreenShift 0.45                     //[0.10 to 1.00] Green colour component shift of the filmic tone shift. Alters the green balance of the shift. Requires FilmicProcess.
-#define BlueShift 0.45                      //[0.10 to 1.00] Blue colour component shift of the filmic tone shift. Alters the blue balance of the shift. Requires FilmicProcess.
-#define ShiftRatio 0.28                     //[0.10 to 1.00] The blending ratio for the base colour and the colour shift. Higher for a stronger effect. Requires FilmicProcess.
+#define FilmicProcess 0                     //[0|1|2] Filmic cross processing. Alters the tone of the scene, for more of a filmic look. 0: off, 1|2: process type.
+#define RedShift 0.50                       //[0.10 to 1.00] Red colour component shift of the filmic processing. Alters the red balance of the shift.
+#define GreenShift 0.45                     //[0.10 to 1.00] Green colour component shift of the filmic processing. Alters the green balance of the shift.
+#define BlueShift 0.45                      //[0.10 to 1.00] Blue colour component shift of the filmic processing. Alters the blue balance of the shift.
+#define ShiftRatio 0.25                     //[0.10 to 1.00] The blending ratio for the base colour and the colour shift. Higher for a stronger effect. 
 
 //##[SHARPEN OPTIONS]##
 #define SharpenStrength 0.75                //[0.10 to 1.00] Strength of the texture sharpening effect. This is the maximum strength that will be used.
@@ -71,7 +72,7 @@
 #define DebugSharpen 0                      //[0 or 1] Visualize the sharpening effect. Useful for fine-tuning. Best to disable other effects, to see edge detection clearly.
 
 //##[CSHADE OPTIONS]##
-#define EdgeStrength 1.50                   //[0.00 to 4.00] Overall strength of the cel edge outline effect.  0.00 = no outlines.
+#define EdgeStrength 1.50                   //[0.00 to 4.00] Overall strength of the cel edge outline effect.  0.00: no outlines.
 #define EdgeFilter 0.60                     //[0.10 to 2.00] Filters out fainter cel edges. Use it for balancing the cel edge density. EG: for faces, foliage, etc. Raise to filter out more edges.
 #define EdgeThickness 1.00                  //[0.50 to 4.00] Thickness of the cel edges. Increase for thicker outlining.  Note: when downsampling, you may need to raise this further to keep the edges as noticeable.
 #define PaletteType 2                       //[1|2|3] The colour palette to use. 1 is Game Original, 2 is Animated Shading, 3 is Water Painting (Default is 2: Animated Shading). #!Options below don't affect palette 1.
@@ -83,7 +84,7 @@
 #define Gamma 2.20                          //[1.5 to 4.0] Gamma correction. Decrease for lower gamma(darker). Increase for higher gamma(brighter). (Default: 2.2)
 
 //##[VIBRANCE OPTIONS]##
-#define Vibrance 0.10                       //[-1.00 to 1.00] Adjust the vibrance of pixels depending on their original saturation. 0.00 is original vibrance.
+#define Vibrance 0.20                       //[-1.00 to 1.00] Locally adjust the vibrance of pixels depending on their original saturation. 0.00 is original vibrance.
 
 //##[CONTRAST OPTIONS]##
 #define Contrast 0.35                       //[0.00 to 2.00] The amount of contrast you want. Controls the overall contrast strength.
@@ -98,13 +99,14 @@
                              [GLOBALS/FUNCTIONS]
 ------------------------------------------------------------------------------*/
 
+static float delta = 0.001;
 static float2 pixelSize = PIXEL_SIZE;
 static float2 screenSize = SCREEN_SIZE;
 static float2 invDefocus = float2(1.0 / 3840.0, 1.0 / 2160.0);
 static const float3 lumCoeff = float3(0.2126729, 0.7151522, 0.0721750);
 
-Texture2D thisframeTex;
-SamplerState s0
+texture thisframeTex;
+sampler s0 = sampler_state
 {
     Texture = <thisframeTex>;
     MinFilter = Linear;
@@ -117,13 +119,13 @@ SamplerState s0
 
 struct VS_INPUT
 {
-    float4 vertPos : POSITION;
+    float4 vertPos : POSITION0;
     float2 UVCoord : TEXCOORD0;
 };
 
 struct VS_OUTPUT
 {
-    float4 vertPos : SV_POSITION;
+    float4 vertPos : POSITION0;
     float2 UVCoord : TEXCOORD0;
 };
 
@@ -132,11 +134,6 @@ struct PS_OUTPUT
     float4 color : COLOR0;
 };
 
-float RGBLuminance(float3 color)
-{
-    return dot(color.xyz, lumCoeff);
-}
-
 float AvgLuminance(float3 color)
 {
     return sqrt((color.x * color.x * lumCoeff.x) +
@@ -144,7 +141,18 @@ float AvgLuminance(float3 color)
                 (color.z * color.z * lumCoeff.z));
 }
 
+float smootherstep(float a, float b, float x)
+{
+    x = saturate((x - a) / (b - a));
+    return x*x*x*(x*(x * 6 - 15) + 10);
+}
+
 /*
+float RGBLuminance(float3 color)
+{
+    return dot(color.xyz, lumCoeff);
+}
+
 float4 DebugClipping(float4 color)
 {
     if (color.x >= 0.99999 && color.y >= 0.99999 &&
@@ -155,7 +163,6 @@ float4 DebugClipping(float4 color)
     return color;
 }
 */
-
 
 /*------------------------------------------------------------------------------
                             [VERTEX CODE SECTION]
@@ -176,7 +183,7 @@ VS_OUTPUT FrameVS(VS_INPUT Input)
 ------------------------------------------------------------------------------*/
 
 #if (GAMMA_CORRECTION == 1)
-float3 RGBGammaToLinear(in float3 color, in float gamma)
+float3 RGBGammaToLinear(float3 color, float gamma)
 {
     color = saturate(color);
     color.r = (color.r <= 0.0404482362771082) ?
@@ -189,7 +196,7 @@ float3 RGBGammaToLinear(in float3 color, in float gamma)
     return color;
 }
 
-float3 LinearToRGBGamma(in float3 color, in float gamma)
+float3 LinearToRGBGamma(float3 color, float gamma)
 {
     color = saturate(color);
     color.r = (color.r <= 0.00313066844250063) ?
@@ -218,66 +225,77 @@ float4 GammaPass(float4 color, float2 texcoord)
 ------------------------------------------------------------------------------*/
 
 #if (BLENDED_BLOOM == 1)
-float3 BlendAddLight(in float3 color, in float3 bloom)
+float3 BlendAddLight(float3 bloom, float3 blend)
 {
-    return saturate(color + bloom);
+    return saturate(bloom + blend);
 }
 
-float3 BlendScreen(in float3 color, in float3 bloom)
+float3 BlendScreen(float3 bloom, float3 blend)
 {
-    return (color + bloom) - (color * bloom);
+    return (bloom + blend) - (bloom * blend);
 }
 
-float3 BlendLuma(in float3 color, in float3 bloom)
+float3 BlendAddGlow(float3 bloom, float3 blend)
 {
-    float lumavg = AvgLuminance(color + bloom);
-    return lerp((color * bloom), (1.0 - ((1.0 - color) * (1.0 - bloom))), lumavg);
+    float glow = smootherstep(0.0, 1.0, AvgLuminance(bloom));
+    return lerp(saturate(bloom + blend),
+    (blend + blend) - (blend * blend), glow);
 }
 
-float3 BlendGlow(in float3 color, in float3 bloom)
+float3 BlendGlow(float3 bloom, float3 blend)
 {
-    float glow = smoothstep(0.0, 1.0, AvgLuminance(color.rgb));
-    return lerp((color + bloom) - (color * bloom), (bloom + bloom) - (bloom * bloom), glow);
+    float glow = smootherstep(0.0, 1.0, AvgLuminance(bloom));
+    return lerp((bloom + blend) - (bloom * blend),
+    (blend + blend) - (blend * blend), glow);
 }
 
-float3 BlendOverlay(in float3 color, in float3 bloom)
+float3 BlendLuma(float3 bloom, float3 blend)
 {
-    float3 overlay = step(0.5, color);
-    overlay = lerp((color * bloom * 2.0), (1.0 - (2.0 * (1.0 - color) * (1.0 - bloom))), overlay);
-
-    return overlay;
+    float lumavg = smootherstep(0.0, 1.0, AvgLuminance(bloom + blend));
+    return lerp((bloom * blend), (1.0 -
+    ((1.0 - bloom) * (1.0 - blend))), lumavg);
 }
 
-float4 PyramidFilter(in sampler2D tex, in float2 texcoord, in float2 width)
+float3 BlendOverlay(float3 bloom, float3 blend)
 {
-    float4 color = tex2D(tex, texcoord + float2(0.5, 0.5) * width);
-    color += tex2D(tex, texcoord + float2(-0.5,  0.5) * width);
-    color += tex2D(tex, texcoord + float2(0.5, -0.5) * width);
-    color += tex2D(tex, texcoord + float2(-0.5, -0.5) * width);
-    color *= 0.25;
+    float3 overlay = step(0.5, bloom);
+    return lerp((bloom * blend * 2.0), (1.0 - (2.0 *
+    (1.0 - bloom) * (1.0 - blend))), overlay);
+}
+
+float4 PyramidFilter(sampler tex, float2 texcoord, float2 width)
+{
+    float4 X = tex2D(tex, texcoord + float2(0.5, 0.5) * width);
+    float4 Y = tex2D(tex, texcoord + float2(-0.5,  0.5) * width);
+    float4 Z = tex2D(tex, texcoord + float2(0.5, -0.5) * width);
+    float4 W = tex2D(tex, texcoord + float2(-0.5, -0.5) * width);
+
+    return (X + Y + Z + W) / 4.0;
+}
+
+float3 BloomCorrection(float3 color)
+{
+    float3 bloom = (color.rgb - 0.5) * 2.0;
+
+    bloom.r = 2.0 / 3.0 * (1.0 - (bloom.r * bloom.r));
+    bloom.g = 2.0 / 3.0 * (1.0 - (bloom.g * bloom.g));
+    bloom.b = 2.0 / 3.0 * (1.0 - (bloom.b * bloom.b));
+
+    bloom.r = saturate(color.r + BloomReds * bloom.r);
+    bloom.g = saturate(color.g + BloomGreens * bloom.g);
+    bloom.b = saturate(color.b + BloomBlues * bloom.b);
+
+    color = bloom;
 
     return color;
 }
 
-float3 BloomCorrection(in float3 color)
-{
-    float X = 1.0 / (1.0 + exp(float(BloomReds) / 2.0));
-    float Y = 1.0 / (1.0 + exp(float(BloomGreens) / 2.0));
-    float Z = 1.0 / (1.0 + exp(float(BloomBlues) / 2.0));
-
-    color.r = (1.0 / (1.0 + exp(float(-BloomReds) * (color.r - 0.5))) - X) / (1.0 - 2.0 * X);
-    color.g = (1.0 / (1.0 + exp(float(-BloomGreens) * (color.g - 0.5))) - Y) / (1.0 - 2.0 * Y);
-    color.b = (1.0 / (1.0 + exp(float(-BloomBlues) * (color.b - 0.5))) - Z) / (1.0 - 2.0 * Z);
-
-    return saturate(color);
-}
-
 float4 BloomPass(float4 color, float2 texcoord)
 {
-    float defocus = 1.25;
     float anflare = 4.00;
+    float defocus = float(BloomDefocus);
 
-    float4 bloom = PyramidFilter(s0, texcoord, invDefocus * defocus);
+    float4 bloom = PyramidFilter(s0, texcoord, pixelSize * defocus);
 
     float2 dx = float2(invDefocus.x * float(BloomWidth), 0.0);
     float2 dy = float2(0.0, invDefocus.y * float(BloomWidth));
@@ -285,43 +303,43 @@ float4 BloomPass(float4 color, float2 texcoord)
     float2 mdx = mul(2.0, dx);
     float2 mdy = mul(2.0, dy);
 
-    float4 bloomBlend = bloom * 0.22520613262190495;
+    float4 blend = bloom * 0.22520613262190495;
 
-    bloomBlend += 0.002589001911021066 * tex2D(s0, texcoord - mdx + mdy);
-    bloomBlend += 0.010778807494659370 * tex2D(s0, texcoord - dx + mdy);
-    bloomBlend += 0.024146616900339800 * tex2D(s0, texcoord + mdy);
-    bloomBlend += 0.010778807494659370 * tex2D(s0, texcoord + dx + mdy);
-    bloomBlend += 0.002589001911021066 * tex2D(s0, texcoord + mdx + mdy);
+    blend += 0.002589001911021066 * tex2D(s0, texcoord - mdx + mdy);
+    blend += 0.010778807494659370 * tex2D(s0, texcoord - dx + mdy);
+    blend += 0.024146616900339800 * tex2D(s0, texcoord + mdy);
+    blend += 0.010778807494659370 * tex2D(s0, texcoord + dx + mdy);
+    blend += 0.002589001911021066 * tex2D(s0, texcoord + mdx + mdy);
 
-    bloomBlend += 0.010778807494659370 * tex2D(s0, texcoord - mdx + dy);
-    bloomBlend += 0.044875475183061630 * tex2D(s0, texcoord - dx + dy);
-    bloomBlend += 0.100529757860782610 * tex2D(s0, texcoord + dy);
-    bloomBlend += 0.044875475183061630 * tex2D(s0, texcoord + dx + dy);
-    bloomBlend += 0.010778807494659370 * tex2D(s0, texcoord + mdx + dy);
+    blend += 0.010778807494659370 * tex2D(s0, texcoord - mdx + dy);
+    blend += 0.044875475183061630 * tex2D(s0, texcoord - dx + dy);
+    blend += 0.100529757860782610 * tex2D(s0, texcoord + dy);
+    blend += 0.044875475183061630 * tex2D(s0, texcoord + dx + dy);
+    blend += 0.010778807494659370 * tex2D(s0, texcoord + mdx + dy);
 
-    bloomBlend += 0.024146616900339800 * tex2D(s0, texcoord - mdx);
-    bloomBlend += 0.100529757860782610 * tex2D(s0, texcoord - dx);
-    bloomBlend += 0.100529757860782610 * tex2D(s0, texcoord + dx);
-    bloomBlend += 0.024146616900339800 * tex2D(s0, texcoord + mdx);
+    blend += 0.024146616900339800 * tex2D(s0, texcoord - mdx);
+    blend += 0.100529757860782610 * tex2D(s0, texcoord - dx);
+    blend += 0.100529757860782610 * tex2D(s0, texcoord + dx);
+    blend += 0.024146616900339800 * tex2D(s0, texcoord + mdx);
 
-    bloomBlend += 0.010778807494659370 * tex2D(s0, texcoord - mdx - dy);
-    bloomBlend += 0.044875475183061630 * tex2D(s0, texcoord - dx - dy);
-    bloomBlend += 0.100529757860782610 * tex2D(s0, texcoord - dy);
-    bloomBlend += 0.044875475183061630 * tex2D(s0, texcoord + dx - dy);
-    bloomBlend += 0.010778807494659370 * tex2D(s0, texcoord + mdx - dy);
+    blend += 0.010778807494659370 * tex2D(s0, texcoord - mdx - dy);
+    blend += 0.044875475183061630 * tex2D(s0, texcoord - dx - dy);
+    blend += 0.100529757860782610 * tex2D(s0, texcoord - dy);
+    blend += 0.044875475183061630 * tex2D(s0, texcoord + dx - dy);
+    blend += 0.010778807494659370 * tex2D(s0, texcoord + mdx - dy);
 
-    bloomBlend += 0.002589001911021066 * tex2D(s0, texcoord - mdx - mdy);
-    bloomBlend += 0.010778807494659370 * tex2D(s0, texcoord - dx - mdy);
-    bloomBlend += 0.024146616900339800 * tex2D(s0, texcoord - mdy);
-    bloomBlend += 0.010778807494659370 * tex2D(s0, texcoord + dx - mdy);
-    bloomBlend += 0.002589001911021066 * tex2D(s0, texcoord + mdx - mdy);
-    bloomBlend = lerp(color, bloomBlend, float(BlendStrength));
+    blend += 0.002589001911021066 * tex2D(s0, texcoord - mdx - mdy);
+    blend += 0.010778807494659370 * tex2D(s0, texcoord - dx - mdy);
+    blend += 0.024146616900339800 * tex2D(s0, texcoord - mdy);
+    blend += 0.010778807494659370 * tex2D(s0, texcoord + dx - mdy);
+    blend += 0.002589001911021066 * tex2D(s0, texcoord + mdx - mdy);
+    blend = lerp(color, blend, float(BlendStrength));
 
-    bloom.rgb = BloomType(bloom.rgb, bloomBlend.rgb);
-    bloom.rgb = BloomCorrection(bloom.rgb);
+    bloom.xyz = BloomType(bloom.xyz, blend.xyz);
+    bloom.xyz = BloomCorrection(bloom.xyz);
 
-    color.a = AvgLuminance(color.rgb);
-    bloom.a = AvgLuminance(bloom.rgb);
+    color.a = AvgLuminance(color.xyz);
+    bloom.a = AvgLuminance(bloom.xyz);
     bloom.a *= anflare;
 
     color = lerp(color, bloom, float(BloomStrength));
@@ -335,56 +353,64 @@ float4 BloomPass(float4 color, float2 texcoord)
 ------------------------------------------------------------------------------*/
 
 #if (SCENE_TONEMAPPING == 1)
-float4 ScaleBlk(in float4 color)
+float3 FilmicALU(float3 color)
 {
-    color = float4(color.rgb * pow(abs(max(color.r,
-    max(color.g, color.b))), float(BlackLevels)), color.a);
-    
-    return color;
+    float3 tone = color;
+    static const float gamma = 2.233;
+
+    tone = max(0, tone - 0.004);
+    tone = (tone * (6.2 * tone + 0.5)) / (tone * (6.2 * tone + 1.7) + 0.06);
+
+    tone.r = pow(tone.r, gamma);
+    tone.g = pow(tone.g, gamma);
+    tone.b = pow(tone.b, gamma);
+
+    return lerp(color, tone, float(ToneAmount) / 1.2);
+
 }
 
-float3 FilmicTonemap(in float3 color)
+float3 FilmicCurve(float3 color)
 {
-    float3 Q = color.xyz;
+    float3 X = color;
 
     float A = 0.10;
     float B = 0.30;
     float C = 0.10;
     float D = float(ToneAmount);
-    float E = 0.02;
+    float E = 0.02 + delta;
     float F = 0.30;
     float W = float(WhitePoint);
 
-    float3 numerator = ((Q*(A*Q + C*B) + D*E) / (Q*(A*Q + B) + D*F)) - E / F;
-    float denominator = ((W*(A*W + C*B) + D*E) / (W*(A*W + B) + D*F)) - E / F;
+    float3 sum = ((X*(A*X + C*B) + D*E) / (X*(A*X + B) + D*F)) - E / F;
+    float denom = ((W*(A*W + C*B) + D*E) / (W*(A*W + B) + D*F)) - E / F;
 
-    color.xyz = numerator / denominator;
+    color = sum / denom;
 
     return saturate(color);
 }
 
-float3 CrossShift(in float3 color)
+float3 CrossShift(float3 color)
 {
-    float3 colMood;
+    float3 cross;
 
     float2 CrossMatrix[3] = {
     float2 (0.96, 0.04),
     float2 (0.99, 0.01),
     float2 (0.97, 0.03), };
 
-    colMood.r = float(RedShift) * CrossMatrix[0].x + CrossMatrix[0].y;
-    colMood.g = float(GreenShift) * CrossMatrix[1].x + CrossMatrix[1].y;
-    colMood.b = float(BlueShift) * CrossMatrix[2].x + CrossMatrix[2].y;
+    cross.r = float(RedShift) * CrossMatrix[0].x + CrossMatrix[0].y;
+    cross.g = float(GreenShift) * CrossMatrix[1].x + CrossMatrix[1].y;
+    cross.b = float(BlueShift) * CrossMatrix[2].x + CrossMatrix[2].y;
 
-    float fLum = AvgLuminance(color.xyz);
-    colMood = lerp(0.0, colMood, saturate(fLum * 2.0));
-    colMood = lerp(colMood, 1.0, saturate(fLum - 0.5) * 2.0);
-    float3 colOutput = lerp(color, colMood, saturate(fLum * float(ShiftRatio)));
+    float lum = AvgLuminance(color);
+    cross = lerp(0.0, cross, saturate(lum * 2.0));
+    cross = lerp(cross, 1.0, saturate(lum - 0.5) * 2.0);
+    color = lerp(color, cross, saturate(lum * float(ShiftRatio)));
 
-    return colOutput;
+    return color;
 }
 
-float3 ColorCorrection(in float3 color)
+float3 ColorCorrection(float3 color)
 {
     float X = 1.0 / (1.0 + exp(float(RedCurve) / 2.0));
     float Y = 1.0 / (1.0 + exp(float(GreenCurve) / 2.0));
@@ -399,14 +425,16 @@ float3 ColorCorrection(in float3 color)
 
 float4 TonemapPass(float4 color, float2 texcoord)
 {
-    const float delta = 0.001;
-    const float wpoint = pow(1.002, 2.0);
-    
-    color = ScaleBlk(color);
+    float avgluminance = AvgLuminance(Luminance);
+    float wpoint = max(color.r, max(color.g, color.b)); wpoint /= wpoint;
 
-    if (CorrectionPalette == 1) { color.rgb = ColorCorrection(color.rgb); }
+    color.rgb *= pow(abs(max(color.r, max(color.g, color.b))), float(BlackLevels));
+
     if (FilmicProcess == 1) { color.rgb = CrossShift(color.rgb); }
-    if (TonemapType == 1) { color.rgb = FilmicTonemap(color.rgb); }
+    if (TonemapType == 1) { color.rgb = FilmicCurve(color.rgb); }
+
+    if (TonemapType == 2) { color.rgb = FilmicALU(color.rgb); }
+    if (CorrectionPalette == 1) { color.rgb = ColorCorrection(color.rgb); }
 
     // RGB -> XYZ conversion
     static const float3x3 RGB2XYZ = { 0.4124564, 0.3575761, 0.1804375,
@@ -418,15 +446,15 @@ float4 TonemapPass(float4 color, float2 texcoord)
     // XYZ -> Yxy conversion
     float3 Yxy;
 
-    Yxy.r = XYZ.g;                              // copy luminance Y
-    Yxy.g = XYZ.r / (XYZ.r + XYZ.g + XYZ.b);    // x = X / (X + Y + Z)
-    Yxy.b = XYZ.g / (XYZ.r + XYZ.g + XYZ.b);    // y = Y / (X + Y + Z)
+    Yxy.r = XYZ.g;                                  // copy luminance Y
+    Yxy.g = XYZ.r / (XYZ.r + XYZ.g + XYZ.b);        // x = X / (X + Y + Z)
+    Yxy.b = XYZ.g / (XYZ.r + XYZ.g + XYZ.b);        // y = Y / (X + Y + Z)
 
-    if (CorrectionPalette == 2) { Yxy.rgb = ColorCorrection(Yxy.rgb); }
-    if (TonemapType == 2) { Yxy.r = FilmicTonemap(Yxy.rgb).r; }
+    if (TonemapType == 2) { Yxy.r = FilmicCurve(Yxy).r; }
+    if (CorrectionPalette == 2) { Yxy = ColorCorrection(Yxy); }
 
     // (Lp) Map average luminance to the middlegrey zone by scaling pixel luminance
-    float Lp = Yxy.r * float(Exposure) / (float(Luminance) + delta);
+    float Lp = Yxy.r * float(Exposure) / (avgluminance + delta);
 
     // (Ld) Scale all luminance within a displayable range of 0 to 1
     Yxy.r = (Lp * (1.0 + Lp / wpoint)) / (1.0 + Lp);
@@ -436,7 +464,8 @@ float4 TonemapPass(float4 color, float2 texcoord)
     XYZ.g = Yxy.r;                                  // copy luminance Y
     XYZ.b = Yxy.r * (1.0 - Yxy.g - Yxy.b) / Yxy.b;  // Z = Y * (1-x-y) / y
 
-    if (CorrectionPalette == 3) { XYZ.rgb = ColorCorrection(XYZ.rgb); }
+    if (FilmicProcess == 2) { XYZ = CrossShift(XYZ); }
+    if (CorrectionPalette == 3) { XYZ = ColorCorrection(XYZ); }
 
     // XYZ -> RGB conversion
     static const float3x3 XYZ2RGB = { 3.2404542,-1.5371385,-0.4985314,
@@ -468,7 +497,7 @@ float Cubic(float coeff)
     return (x + y + z + w) / 4.0;
 }
 
-float4 SampleBicubic(in SamplerState texSample, in float2 TexCoord)
+float4 SampleBicubic(sampler texSample, float2 TexCoord)
 {
     float texelSizeX = pixelSize.x * float(SharpenBias);
     float texelSizeY = pixelSize.y * float(SharpenBias);
@@ -532,7 +561,7 @@ float4 TexSharpenPass(float4 color, float2 texcoord)
 #if (CEL_SHADING == 1)
 float3 GetYUV(float3 RGB)
 {
-    const float3x3 RGB2YUV = {
+    static const float3x3 RGB2YUV = {
     0.2126, 0.7152, 0.0722,
    -0.09991,-0.33609, 0.436,
     0.615, -0.55861, -0.05639 };
@@ -542,7 +571,7 @@ float3 GetYUV(float3 RGB)
 
 float3 GetRGB(float3 YUV)
 {
-    const float3x3 YUV2RGB = {
+    static const float3x3 YUV2RGB = {
     1.000, 0.000, 1.28033,
     1.000,-0.21482,-0.38059,
     1.000, 2.12798, 0.000 };
@@ -609,7 +638,7 @@ float4 CelPass(float4 color, float2 uv0)
     #if (PaletteType == 1)
         color.rgb = lerp(color.rgb, color.rgb + pow(edge, EdgeFilter) * -EdgeStrength, EdgeStrength);
     #elif (PaletteType == 2)
-        color.rgb = lerp(color.rgb + pow(edge, EdgeFilter) * -EdgeStrength, shadedColor, 0.30);
+        color.rgb = lerp(color.rgb + pow(edge, EdgeFilter) * -EdgeStrength, shadedColor, 0.25);
     #elif (PaletteType == 3)
         color.rgb = lerp(shadedColor + edge * -EdgeStrength, pow(edge, EdgeFilter) * -EdgeStrength + color.rgb, 0.5);
     #endif
@@ -634,7 +663,7 @@ float4 ContrastPass(float4 color, float2 texcoord)
     //S-Curve - Cubic Bezier spline
     float3 a = float3(0.00, 0.00, 0.00);
     float3 b = float3(0.25, 0.25, 0.25);
-    float3 c = float3(1.00, 1.00, 1.00);
+    float3 c = float3(0.95, 0.95, 0.95);
     float3 d = float3(1.00, 1.00, 1.00);
 
     float3 ab = lerp(a, b, x);          //point between a and b (green)
@@ -732,6 +761,7 @@ technique t0
         PixelShader = compile ps_3_0 postProcessing();
         ZEnable = false;
         CullMode = NONE;
+        ShadeMode = Phong;
         AlphaBlendEnable = false;
         AlphaTestEnable = false;
         SRGBWriteEnable = USE_SRGB;


### PR DESCRIPTION
* Resolved a tiny amount of clipping, introduced in the previous update. My tone mapping not only causes no clipping, but It can also reduce or completely resolve both high and low clipping from the default game. Example: The games I'm currently playing (The Witcher 2 / DA:O) have clipping of both blacks and whites by default. My tone mapping resolves both.
* Removed input arguments (from compiler test), that I'd forgotten about.
* Added a new bloom type to choose from.
* Added new bloom-exclusive colour correction, and a defocus option.
* Improved bloom soft lighting. (Note: I add a lot of options for a reason - if people don't like the soft look of the bloom, it can be totally controlled, and/or disabled altogether, for a sharp bloom). Experiment with the options.
* Improvements to tone mapping, and added a new tonemap operator type(HDR Filmic ALU) to the existing options. 0 is LDR, 1 is HDR, 2 is a hybrid filmic ALU type with slight rgb-xyz colour grading, that I was working on, and quite like. It's more suited to games that have a realisitc look, typically.
* Improvements to cross processing, &  added a new palette type to choose.
* Added independent component rgb options to the vibrance.
* Added Sub-pixel Dithering to the list of effects to choose, also added hw dithering to the effect state.
* Updated some options, and their descriptions, to reflect changes.

Default settings (DA:O)
https://farm8.staticflickr.com/7584/16558127478_28c2943d57_o.png