### PR TITLE
Removed deprecated settings from ffxiiiimg GeDoSaTo.ini

### DIFF
--- a/pack/config/ffxiiiimg/GeDoSaTo.ini
+++ b/pack/config/ffxiiiimg/GeDoSaTo.ini
@@ -8,20 +8,6 @@ clearRenderResolutions
 renderResolution 3840x2160@60
 #renderResolution 4480x2520@60
 
-## Anti Aliasing
-# MSAA sample count, default 4, other options: 2, 8
-# higher = higher performance impact
-MSAASampleCount 4
-# Enable coverage sampling (CSAA on NV, EQAA on AMD) if HW supports it
-# (improvement for small performance hit)
-enableCoverageSampling false
-
-## Shadow Resolution
-# 1 = default
-# sensible values: 2, 4, 8 (extreme)
-# higher numbers = larger performance impact
-shadowScale 1
-
 ## Required settings, don't change
 injectPSHash 1329c9bf
 maxScreenshotParallelism -1


### PR DESCRIPTION
Removed some FF13Plugin-dependant settings since the FF13 plugin was disabled in 0.16.1759.