### PR TITLE
Removed deprecated settings in FFXIII profile

### DIFF
--- a/pack/config/ffxiiiimg/GeDoSaTo.ini
+++ b/pack/config/ffxiiiimg/GeDoSaTo.ini
@@ -1,12 +1,6 @@
 # Lines starting with "#" are ignored by GeDoSaTo and used to provide documentation
 
-# This is a profile file for ffxiiiimg
-
-## Rendering Resolution
-# can't select res in-game so write it here
-clearRenderResolutions
-renderResolution 3840x2160@60
-#renderResolution 4480x2520@60
+# This is a profile file for Final Fantasy XIII
 
 ## Required settings, don't change
 injectPSHash 1329c9bf


### PR DESCRIPTION
The rendering resolution can now be selected in the FFXIII launcher so
there's no need for these. Just pick the resolution you want from the
launcher.