### PR TITLE
Add Deband shader

### DIFF
--- a/pack/assets/dx9/post.fx
+++ b/pack/assets/dx9/post.fx
@@ -23,6 +23,7 @@
 #define USE_LOTTES_CRT        0 //[0 or 1] Timothy Lottes' CRT (http://tinyurl.com/od5oyxn http://tinyurl.com/qboke3o)
 #define USE_CARTOON           0 //[0 or 1] Cartoon : "Toon"s the image(Interferes with SMAA, CRT, Bloom, HDR and Lumasharpen).
 #define USE_MONOCHROME        0 //[0 or 1] Monochrome : Monochrome makes the colors disappear.
+#define USE_DEBAND 					0 //[0 or 1] //-Applies debanding to minimize banding artifacts
 
 // Bloom settings
     #define BloomThreshold 20.25 // [0.00 to 50.00] Threshold for what is a bright light (that causes bloom) and what isn't.
@@ -170,6 +171,17 @@
 // Monochrome settings                    
     #define Monochrome_conversion_values  float3(0.18,0.41,0.41)  //[-1.00 to 1.00] Percentage of RGB to include (should sum up to 1.00)
     
+// Deband settings
+	#define DEBAND_RADIUS 32.0 //[0.0:1024.0] //-Sampling radius, higher values will reduce further banding but might also reduce details
+	#define DEBAND_THRESHOLD 0.017 //[0.000:0.100] //-Threshold, higher values will reduce further banding but might also reduce details and increase noise
+	#define DEBAND_SAMPLE_COUNT 8 //[1:8] //-Sample count, higher values are better
+	#define DEBAND_OFFSET_MODE 3 //[1:3] //-1 = cross (axis aligned, fast), 2 = diagonal (45 degrees, slower), 3 = box (fully random, much slower)
+	#define DEBAND_DITHERING 1 //[0:3] //-Additional dithering options to smoothen the output. 0 = No dithering 1 = Ordered dithering, 2 = Random dithering, 3 = Iestyn's RGB dither (Valve)
+
+	//>Deband debug settings<\\
+	#define DEBAND_SKIP_THRESHOLD_TEST 0 //[0:1] //-1 = Skip threshold to see the unfiltered sampling pattern
+	#define DEBAND_OUTPUT_BOOST 1.0 //[-2.0:2.0] //-Default = 1.0. Any value other than the default activates debug mode. When fine-tuning the values you might use both these settings to boost luminance, which should make it easier to see banding artifacts.
+	#define DEBAND_OUTPUT_OFFSET 0.0 //[-1.0:3.0] //-Default = 0.0. Any value other than the default activates debug mode. When fine-tuning the values you might use both these settings to boost luminance, which should make it easier to see banding artifacts.
 // -------------------- Interface -----------------------------------------------
 
 texture2D thisframeTex;
@@ -1839,6 +1851,98 @@ float4 MonochromePass( float4 colorInput )
     return saturate(colorInput);
 }
 
+// ------------------------- Deband -------------------------------------------
+float rand(float2 pos)
+{
+	return frac(sin(dot(pos, float2(12.9898, 78.233))) * 43758.5453);
+}
+
+bool is_within_threshold(float3 original, float3 other)
+{
+	return !any(max(abs(original - other) - DEBAND_THRESHOLD, float3(0.0, 0.0, 0.0))).x;
+}
+
+float4 DebandPass(float4 vpos, float2 texcoord)
+{
+	//float2 RFX_PixelSize = (1.0/SCREEN_WIDTH, 1.0/SCREEN_HEIGHT);
+    float2 step = PIXEL_SIZE * DEBAND_RADIUS;
+    float2 halfstep = step * 0.5;
+
+    //Compute additional sample positions
+    float2 seed = texcoord + timer;
+	#if (DEBAND_OFFSET_MODE == 1)
+		float2 offset = float2(rand(seed), 0.0);
+	#elif (DEBAND_OFFSET_MODE == 2)
+		float2 offset = float2(rand(seed).xx);
+	#elif (DEBAND_OFFSET_MODE == 3)
+		float2 offset = float2(rand(seed), rand(seed + float2(0.1, 0.2)));
+	#endif
+
+    float2 on[8] = {
+        float2( offset.x,  offset.y) * step,
+        float2( offset.y, -offset.x) * step,
+        float2(-offset.x, -offset.y) * step,
+        float2(-offset.y,  offset.x) * step,
+        float2( offset.x,  offset.y) * halfstep,
+        float2( offset.y, -offset.x) * halfstep,
+        float2(-offset.x, -offset.y) * halfstep,
+        float2(-offset.y,  offset.x) * halfstep,
+        };
+		
+		
+    //float4 c0 = tex2D(s0, tex);
+	//float4 c0 = tex2D(RFX_backbufferColor, texcoord);
+	//float4 vpos;
+
+    float3 col0 = tex2D(s0, texcoord).rgb;
+    float4 accu = float4(col0, 1.0);
+
+    for (int i = 0; i < DEBAND_SAMPLE_COUNT; i++)
+    {
+        float4 cn = float4(tex2D(s0, texcoord + on[i]).rgb, 1.0);
+		#if (DEBAND_SKIP_THRESHOLD_TEST == 0)
+			if (is_within_threshold(col0, cn.rgb))
+		#endif
+		accu += cn;
+    }
+
+    accu.rgb /= accu.a;
+
+    //Boost to make it easier to inspect the effect's output
+    if (DEBAND_OUTPUT_OFFSET != 0.0 || DEBAND_OUTPUT_BOOST != 1.0)
+	{
+		accu.rgb -= DEBAND_OUTPUT_OFFSET;
+		accu.rgb *= DEBAND_OUTPUT_BOOST;
+	}
+	
+	//Additional dithering
+	#if (DEBAND_DITHERING == 1)
+		//Ordered dithering
+		float dither_bit  = 8.0;
+		float grid_position = frac( dot(texcoord,(SCREEN_SIZE * float2(1.0/16.0,10.0/36.0))) + 0.25 );
+		float dither_shift = (0.25) * (1.0 / (pow(2,dither_bit) - 1.0));
+		float3 dither_shift_RGB = float3(dither_shift, -dither_shift, dither_shift);
+		dither_shift_RGB = lerp(2.0 * dither_shift_RGB, -2.0 * dither_shift_RGB, grid_position);
+		accu.rgb += dither_shift_RGB;
+	#elif (DEBAND_DITHERING == 2)
+		//Random dithering
+		float dither_bit  = 8.0;
+		float sine = sin(dot(texcoord, float2(12.9898,78.233)));
+		float noise = frac(sine * 43758.5453 + texcoord.x);
+		float dither_shift = (1.0 / (pow(2,dither_bit) - 1.0));
+		float dither_shift_half = (dither_shift * 0.5);
+		dither_shift = dither_shift * noise - dither_shift_half;
+		accu.rgb += float3(-dither_shift, dither_shift, -dither_shift);
+	#elif (DEBAND_DITHERING == 3)
+		//Iestyn's RGB dither (7 asm instructions) from Portal 2 X360, slightly modified for VR
+		//float3 vDither = dot(float2(171.0, 231.0), texcoord * SCREEN_SIZE + RFX_Timer).xxx; //Dynamic dither pattern
+		float3 vDither = dot(float2(171.0, 231.0), texcoord * SCREEN_SIZE).xxx;
+		vDither.rgb = frac( vDither.rgb / float3( 103.0, 71.0, 97.0 ) ) - float3(0.5, 0.5, 0.5);
+		accu.rgb += (vDither.rgb / 255.0);
+	#endif
+	
+	return saturate(accu);
+}
 
 // -------------------- Main -----------------------------------------------
 
@@ -1922,6 +2026,10 @@ float4 postProcessing(VSOUT IN) : COLOR0
 
 #if (USE_MONOCHROME == 1)
     c0 = MonochromePass(c0);
+#endif
+
+#if (USE_DEBAND == 1)
+    c0 = DebandPass(c0, tex);
 #endif
 
     c0.w = 1.0;

--- a/pack/assets/dx9/post.fx
+++ b/pack/assets/dx9/post.fx
@@ -1950,6 +1950,10 @@ float4 postProcessing(VSOUT IN) : COLOR0
 {
     float2 tex = IN.UVCoord;
     float4 c0 = tex2D(s0, tex);
+
+#if (USE_DEBAND == 1)
+    c0 = DebandPass(c0, tex);
+#endif
     
 #if (USE_ADVANCED_CRT == 1)
     c0 = AdvancedCRTPass(c0, tex);
@@ -2026,10 +2030,6 @@ float4 postProcessing(VSOUT IN) : COLOR0
 
 #if (USE_MONOCHROME == 1)
     c0 = MonochromePass(c0);
-#endif
-
-#if (USE_DEBAND == 1)
-    c0 = DebandPass(c0, tex);
 #endif
 
     c0.w = 1.0;


### PR DESCRIPTION
The shader functions perfectly, but I used some weird business that I
feel there is probably a better solution for (seeing as its partly using
passed in parameters.)

@line 1897, I used 

tex2D(s0, texcoord).rgb;  

tex2D(s0, texcoord) should be identical to vpos(the first passed in parameter) in this case.  The
reason I did this is because @line 1902, a for loop is used to iterate
through the positions with:

tex2D(s0, texcoord + on[i]).rgb

I didn't know the proper way to utilize the above vpos, as well as
adding the iteration to texcoord for each pass.

If there is a more elegant solution to this you know, feel free to
modify it.