### PR TITLE
Re-enable FF13 plugin

### DIFF
--- a/defs/plugins.def
+++ b/defs/plugins.def
@@ -3,10 +3,10 @@
 
 PLUGIN("Dark Souls 2", "DarkSoulsII", DS2Plugin)
 PLUGIN("Mitsurugi Kamui Hikae", "mitsurugi", MitsurugiPlugin)
-//PLUGIN("Final Fantasy XIII", "ffxiiiimg", FF13Plugin)
+PLUGIN("Final Fantasy XIII", "ffxiiiimg", FF13Plugin)
 //PLUGIN("Dynasty Warriors 8", "Launch", DW8Plugin)
 PLUGIN("Tales of Zestiria", "Tales of Zestiria", ZestiriaPlugin)
-PLUGIN("Lightning Returns FInal Fantasy XIII", "LRFF13", LightningReturnsPlugin)
+PLUGIN("Lightning Returns Final Fantasy XIII", "LRFF13", LightningReturnsPlugin)
 PLUGIN("Tales of Symphonia", "Symphonia", SymphoniaPlugin)
 
 // this should always be last


### PR DESCRIPTION
Changing the resolution from the official launcher doesn't work correctly, it does change the resolution but causes some text to be missing while analyzing the monsters.
With the FF13 plugin enabled, it works as it should (ie. no more missing text while downsampling from a higher resolution than 720p).