### PR TITLE
Grim Dawn hud toggle GeDoSaTo profile.

### DIFF
--- a/pack/config/Grim-Dawn/GeDoSaTo.ini
+++ b/pack/config/Grim-Dawn/GeDoSaTo.ini
@@ -3,5 +3,5 @@
 
 #Grim Dawn HUD toggle.
 
-injectPSHash 5e33ae8f
+injectPSHash 7c689f6e
 injectDelayAfterDraw true

--- a/pack/config/Grim-Dawn/GeDoSaTo.ini
+++ b/pack/config/Grim-Dawn/GeDoSaTo.ini
@@ -1,0 +1,7 @@
+# Lines starting with "#" are ignored by GeDoSaTo and used to provide documentation
+# read them before changing anything!
+
+#Grim Dawn HUD toggle.
+
+injectPSHash 5e33ae8f
+injectDelayAfterDraw true


### PR DESCRIPTION
First time I'm doing something like this, followed the tutorial on PCGamer and found a suitable PSHash for the game to toggle the HUD, can't get rid of the "-" in the folder name though, it's supposed to be "Grim Dawn" for "Grim Dawn.exe" but Github auto-adds the "-" in-between for some reason, sorry about that but I don't know how to fix it.